### PR TITLE
LIB001-568: CSS changes to make search results display nicely

### DIFF
--- a/theme-local/art/css/style.css
+++ b/theme-local/art/css/style.css
@@ -108,7 +108,7 @@ body, select, input, textarea 	{ color: #555; line-height: 18px; font-family: Ar
 h1, h2, h3, h4, h5, h6          { text-rendering: optimizeLegibility; color: #000000; font-weight: bold; }
 h1 								{ font-size: 18px; line-height: 24px; margin: 30px 0 17px 0px; position: relative; }
 h2 								{ font-size: 16px; line-height: 36px; margin: 0 0 0 0; }
-h3 								{ font-size: 14px; line-height: 18px; margin: 0 0 9px 0; }
+h3 								{ color: #00315F; font-size: 14px; line-height: 18px; margin: 0 0 9px 0; }
 
 h1.itemtitle 					{ font-size: 18px; line-height: 24px; margin: 20px 0 10px 0px; position: relative; text-transform: uppercase; }
 
@@ -160,12 +160,13 @@ header				{ position: relative; width: 940px;}
 .search .advanced 				{ text-transform: uppercase; font-size: 10px; text-decoration: none; }
 .search .advanced:hover			{ text-decoration: underline; }
 
-.iteminfo           { width: 660px; margin-top: 10px;position:relative; padding-right: 20px;min-height:32px;}
-.thumbnailimage     { position:relative; width: 500px; float:left;}
-.tagdiv             { position:relative;width: 250px;float:left; }
-.tagdiv a           { font-size: 13px; color: #fff;background: #00315F; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
+.item-div           { width: 600px; text-align: left; display: block;}
+.iteminfo           { display: block; margin-top: 10px; min-height:100px; text-align: left; width: 70%; float:left;}
+.thumbnailImage     { display: block; text-align: left; width: 25%; float: right;}
+.tagdiv             { position:relative; width: 250px;float:left; }
+.tagdiv a           { font-size: 13px; color:#00315F; background: #58A09D; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
 .tagdiv a.bold      { font-weight: bold; }
-.tagdiv a:hover     { background: #BBBBBC; color: #000; }
+.tagdiv a:hover     { background: #00315F; color: #fff; }
 
 .col-sidebar h4						{ color: #fff; line-height: 26px; font-weight: bold; text-transform: uppercase; font-size: 12px; margin-bottom: 17px; background: #00315F; padding: 0 17px; }
 .col-sidebar h4 a 					{
@@ -193,9 +194,9 @@ header				{ position: relative; width: 940px;}
 .col-sidebar ul.related .tags a:hover		{ text-decoration: none; background: #00315F; }
 
 .tags					{ margin-top: 5px; margin: 0; }
-.tags a 				{ font-size: 13px; background: #AAA79E; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
+.tags a 				{ font-size: 13px; background: #58A09D; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
 .tags a.bold			{ font-weight: bold; }
-.tags a:hover			{ background: #00315F; color: #fff; }
+.tags a:hover			{ background: #00315F; color: #fff; text-decoration: underline; }
 
 footer                  { display: block; border-bottom: 1px solid #58A09D; padding-bottom: 10px; margin-bottom: 15px; width: 660px; height: 130px;}
 

--- a/theme/art/views/search_results.php
+++ b/theme/art/views/search_results.php
@@ -68,67 +68,44 @@
 
         <li<?php if($index == 0) { echo ' class="first"'; } elseif($index == sizeof($docs) - 1) { echo ' class="last"'; } ?>>
             <!--span class="icon <?php echo $type?>"></span-->
-
-            <div class =  "thumbnailImage">
-                <?php if(isset($doc[$bitstream_field])) {
-                    //SR clone text from bitstream helpers to get individual aspects of bitstream. Cannot call bitstream helpers from here.
-                    $i = 0;
-                    foreach ($doc[$bitstream_field] as $bitstream) {
-
-                        $thumbnail = $doc[$thumbnail_field][0];
-                        $segments = explode("##", $thumbnail);
-                        $filename = $segments[1];
-                        $handle = $segments[3];
-                        $seq = $segments[4];
-                        $handle_id = preg_replace('/^.*\//', '',$handle);
-                        $uri = './record/'.$handle_id.'/'.$seq.'/'.$filename;
-                        $thumbnailLink = $this->skylight_utilities->getBitstreamThumbLinkParameterised($bitstream, $thumbnail, 'test', '140px', 0, 'style="display: block; margin-left: auto; margin-right: auto;" ');
-
-                        if ($i == 0)
-                        {
-                            echo $thumbnailLink;
-                        }
-                        $i++;
-                    }
-                }?>
-            </div>
+        <div class="item-div">
 
             <div class = "iteminfo">
-            <?php if(array_key_exists($author_field,$doc)) { ?>
-                <?php
 
-                $num_authors = 0;
-                foreach ($doc[$author_field] as $author) {
-                    // test author linking
-                    // quick hack that only works if the filter key
-                    // and recorddisplay key match and the delimiter is :
-                    $orig_filter = preg_replace('/ /','+',$author, -1);
-                    $orig_filter = preg_replace('/,/','%2C',$orig_filter, -1);
-                    echo '<a href="./search/*/Author:%22'.$orig_filter.'%22">'.$author.'</a>';
-                    $num_authors++;
-                    if($num_authors < sizeof($doc[$author_field])) {
-                        echo ' ';
-                    }
+
+                <h3><a href="./record/<?php echo $doc['id']?>?highlight=<?php echo $query ?>"><?php echo $doc[$title_field][0]; ?></a>
+                <?php if(array_key_exists($date_field, $doc)) { ?>
+                <?php
+                echo '(' . $doc[$date_field][0] . ')';
+                }
+                elseif(array_key_exists('dateIssuedyear', $doc)) {
+                    echo '( ' . $doc['dateIssuedyear'][0] . ')';
                 }
 
-                ?>
+                ?></h3>
 
-                <h3><a href="./record/<?php echo $doc['id']?>?highlight=<?php echo $query ?>"><?php echo $doc[$title_field][0]; ?></a></h3>
+                <div class="tagdiv">
 
-                <?php } ?>
+                    <?php if(array_key_exists($author_field,$doc)) { ?>
+                        <?php
 
-           <?php if(array_key_exists($date_field, $doc)) { ?>
-                <span>
-                    <?php
-                    echo '(' . $doc[$date_field][0] . ')';
-              }
-                        elseif(array_key_exists('dateIssuedyear', $doc)) {
-                            echo '( ' . $doc['dateIssuedyear'][0] . ')';
+                        $num_authors = 0;
+                        foreach ($doc[$author_field] as $author) {
+                            // test author linking
+                            // quick hack that only works if the filter key
+                            // and recorddisplay key match and the delimiter is :
+                            $orig_filter = preg_replace('/ /','+',$author, -1);
+                            $orig_filter = preg_replace('/,/','%2C',$orig_filter, -1);
+                            echo '<a href="./search/*/Author:%22'.$orig_filter.'%22">'.$author.'</a>';
+                            $num_authors++;
+                            if($num_authors < sizeof($doc[$author_field])) {
+                                echo ' ';
+                            }
                         }
 
-                    ?>
-                    </span>
-                <div class="tagdiv">
+                        ?>
+                    <?php } ?>
+
 
             <?php
             // TODO: Make highlighting configurable
@@ -167,6 +144,31 @@
 
             </div> <!-- close tags div -->
 
+            </div>
+            <div class =  "thumbnailImage">
+                <?php if(isset($doc[$bitstream_field])) {
+                    //SR clone text from bitstream helpers to get individual aspects of bitstream. Cannot call bitstream helpers from here.
+                    $i = 0;
+                    foreach ($doc[$bitstream_field] as $bitstream) {
+
+                        $thumbnail = $doc[$thumbnail_field][0];
+                        $segments = explode("##", $thumbnail);
+                        $filename = $segments[1];
+                        $handle = $segments[3];
+                        $seq = $segments[4];
+                        $handle_id = preg_replace('/^.*\//', '',$handle);
+                        $uri = './record/'.$handle_id.'/'.$seq.'/'.$filename;
+                        $thumbnailLink = $this->skylight_utilities->getBitstreamThumbLinkParameterised($bitstream, $thumbnail, 'test', '140px', 0, 'style="display: block; margin-left: auto; margin-right: auto;" ');
+
+                        if ($i == 0)
+                        {
+                            echo $thumbnailLink;
+                        }
+                        $i++;
+                    }
+                }?>
+            </div>
+            <div class="clearfix"></div>
             </div>
         </li>
             <?php }?>


### PR DESCRIPTION
- css for search_results
  - needed images to go on right (instead of left) otherwise looks strange when there are no images.
- styling of tags
