### PR TITLE
LIB001-648: Fixed filenames with spaces and added clearfix

### DIFF
--- a/theme/art/views/record.php
+++ b/theme/art/views/record.php
@@ -96,17 +96,15 @@ if(isset($solr[$type_field])) {
 
         if (strpos($b_uri, ".jpg") > 0)
         {
+            // is there a main image
             if (!$mainImage) {
 
                 $bitstreamLink = '<div class="main-image">';
 
-                $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $b_uri . '> ';
+                $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
                 $bitstreamLink .= '<img class="record-main-image" src = "'. $b_uri .'">';
                 $bitstreamLink .= '</a>';
 
-                /* $bitstreamLink .= '<p><span class="bitstream_size">';
-                $bitstreamLink .= getBitstreamSize($bitstream);
-                $bitstreamLink .= '</span></p>'; */
                 $bitstreamLink .= '</div>';
 
                 $mainImage = true;
@@ -114,33 +112,14 @@ if(isset($solr[$type_field])) {
             }
             else {
 
-                if(isset($doc[$thumbnail_field])) {
-                    $thumbnail = $doc[$thumbnail_field][0];
+                $t_uri = $b_uri . '.jpg';
 
-                    $t_segments = explode("##", $thumbnail);
-                    $t_filename = $t_segments[1];
-                    $t_handle = $t_segments[3];
-                    $t_seq = $t_segments[4];
-                    $t_handle_id = preg_replace('/^.*\//', '',$t_handle);
-                    $t_uri = './record/'.$t_handle_id.'/'.$t_seq.'/'.$t_filename;
-
-                    $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-                    if($numThumbnails == 0 || $numThumbnails == 4) {
-                        $thumbnailLink[$numThumbnails] .= ' first';
-                    }
-                    $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $t_uri . '> ';
-                    $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-
+                $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
+                if($numThumbnails % 4 === 0) {
+                    $thumbnailLink[$numThumbnails] .= ' first';
                 }
-                else {
-
-                    $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-                    if($numThumbnails == 0 || $numThumbnails == 4) {
-                        $thumbnailLink[$numThumbnails] .= ' first';
-                    }
-                    $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $b_uri . '> ';
-                    $thumbnailLink[$numThumbnails] .= '<img src = "'.$b_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-                }
+                $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $t_uri . '"> ';
+                $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
 
                 $numThumbnails++;
 
@@ -174,13 +153,35 @@ if(isset($solr[$type_field])) {
         echo '<div class="clearfix"></div>';
     }
 
+    $i = 0;
+    $newStrip = false;
     if($numThumbnails > 0) {
 
         echo '<div class="thumbnail-strip">';
 
         foreach($thumbnailLink as $thumb) {
-            echo $thumb;
+
+            if($newStrip)
+            {
+
+                echo '</div><div class="clearfix"></div>';
+                echo '<div class="thumbnail-strip">';
+                echo $thumb;
+                $newStrip = false;
+            }
+            else {
+
+                echo $thumb;
+            }
+
+            $i++;
+
+            // if we're starting a new thumbnail strip
+            if($i % 4 === 0) {
+                $newStrip = true;
+            }
         }
+
         echo '</div><div class="clearfix"></div>';
     }
 

--- a/theme/art/views/search_results.php
+++ b/theme/art/views/search_results.php
@@ -150,23 +150,23 @@
             <div class = "thumbnail-image">
                 <?php if(isset($doc[$bitstream_field])) {
 
-                    //todo check as assumes there is always a thumbnail for a jpg and only jpgs
                     $firstImg = false;
                     foreach ($doc[$bitstream_field] as $bitstream) {
 
-                    $b_segments = explode("##", $bitstream);
-                    $b_filename = $b_segments[1];
-                    $b_handle = $b_segments[3];
-                    $b_seq = $b_segments[4];
-                    $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
-                    $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
+                        $b_segments = explode("##", $bitstream);
+                        $b_filename = $b_segments[1];
+                        $b_handle = $b_segments[3];
+                        $b_seq = $b_segments[4];
+                        $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
+                        $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
 
+                        //todo check as assumes there is always a thumbnail for a jpg and only jpgs
                         if (!$firstImg && strpos($b_uri, ".jpg") > 0)
                         {
                             $firstImg = true;
-                             $t_uri = $b_uri . '.jpg';
+                            $t_uri = $b_uri . '.jpg';
 
-                            $thumbnailLink = '<a title = "' . $doc[$title_field][0] . '" class="fancybox" rel="group' . $j . '" href=' . $b_uri . '> ';
+                            $thumbnailLink = '<a title = "' . $doc[$title_field][0] . '" class="fancybox" rel="group' . $j . '" href="' . $b_uri . '"> ';
                             $thumbnailLink .= '<img src = "'.$t_uri.'" class="search-thumbnail" title="'. $doc[$title_field][0] .'" /></a>';
 
                             echo $thumbnailLink;
@@ -174,9 +174,9 @@
 
                         $j++;
 
-                } // end for each
+                    } // end for each
 
-            } //end if bitstream ?>
+                } //end if bitstream ?>
 
             </div>
             <div class="clearfix"></div>

--- a/theme/clds/views/record.php
+++ b/theme/clds/views/record.php
@@ -89,17 +89,15 @@ if(isset($solr[$type_field])) {
 
             if (strpos($b_uri, ".jpg") > 0)
             {
+                // is there a main image
                 if (!$mainImage) {
 
                     $bitstreamLink = '<div class="main-image">';
 
-                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $b_uri . '> ';
+                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
                     $bitstreamLink .= '<img class="record-main-image" src = "'. $b_uri .'">';
                     $bitstreamLink .= '</a>';
 
-                    /* $bitstreamLink .= '<p><span class="bitstream_size">';
-                    $bitstreamLink .= getBitstreamSize($bitstream);
-                    $bitstreamLink .= '</span></p>'; */
                     $bitstreamLink .= '</div>';
 
                     $mainImage = true;
@@ -107,33 +105,14 @@ if(isset($solr[$type_field])) {
                 }
                 else {
 
-                    if(isset($doc[$thumbnail_field])) {
-                        $thumbnail = $doc[$thumbnail_field][0];
+                    $t_uri = $b_uri . '.jpg';
 
-                        $t_segments = explode("##", $thumbnail);
-                        $t_filename = $t_segments[1];
-                        $t_handle = $t_segments[3];
-                        $t_seq = $t_segments[4];
-                        $t_handle_id = preg_replace('/^.*\//', '',$t_handle);
-                        $t_uri = './record/'.$t_handle_id.'/'.$t_seq.'/'.$t_filename;
-
-                        $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-                        if($numThumbnails == 0 || $numThumbnails == 4) {
-                            $thumbnailLink[$numThumbnails] .= ' first';
-                        }
-                        $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $t_uri . '> ';
-                        $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-
+                    $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
+                    if($numThumbnails % 4 === 0) {
+                        $thumbnailLink[$numThumbnails] .= ' first';
                     }
-                    else {
-
-                        $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-                        if($numThumbnails == 0 || $numThumbnails == 4) {
-                            $thumbnailLink[$numThumbnails] .= ' first';
-                        }
-                        $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $b_uri . '> ';
-                        $thumbnailLink[$numThumbnails] .= '<img src = "'.$b_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-                    }
+                    $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $t_uri . '"> ';
+                    $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
 
                     $numThumbnails++;
 
@@ -167,13 +146,35 @@ if(isset($solr[$type_field])) {
             echo '<div class="clearfix"></div>';
         }
 
+        $i = 0;
+        $newStrip = false;
         if($numThumbnails > 0) {
 
             echo '<div class="thumbnail-strip">';
 
             foreach($thumbnailLink as $thumb) {
-                echo $thumb;
+
+                if($newStrip)
+                {
+
+                    echo '</div><div class="clearfix"></div>';
+                    echo '<div class="thumbnail-strip">';
+                    echo $thumb;
+                    $newStrip = false;
+                }
+                else {
+
+                    echo $thumb;
+                }
+
+                $i++;
+
+                // if we're starting a new thumbnail strip
+                if($i % 4 === 0) {
+                    $newStrip = true;
+                }
             }
+
             echo '</div><div class="clearfix"></div>';
         }
 

--- a/theme/clds/views/search_results.php
+++ b/theme/clds/views/search_results.php
@@ -166,7 +166,7 @@
                             $firstImg = true;
                             $t_uri = $b_uri . '.jpg';
 
-                            $thumbnailLink = '<a title = "' . $doc[$title_field][0] . '" class="fancybox" rel="group' . $j . '" href=' . $b_uri . '> ';
+                            $thumbnailLink = '<a title = "' . $doc[$title_field][0] . '" class="fancybox" rel="group' . $j . '" href="' . $b_uri . '"> ';
                             $thumbnailLink .= '<img src = "'.$t_uri.'" class="search-thumbnail" title="'. $doc[$title_field][0] .'" /></a>';
 
                             echo $thumbnailLink;

--- a/theme/mimed/views/record.php
+++ b/theme/mimed/views/record.php
@@ -88,17 +88,15 @@ if(isset($solr[$type_field])) {
 
             if (strpos($b_uri, ".jpg") > 0)
             {
+                // is there a main image
                 if (!$mainImage) {
 
                     $bitstreamLink = '<div class="main-image">';
 
-                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $b_uri . '> ';
+                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
                     $bitstreamLink .= '<img class="record-main-image" src = "'. $b_uri .'">';
                     $bitstreamLink .= '</a>';
 
-                    /* $bitstreamLink .= '<p><span class="bitstream_size">';
-                    $bitstreamLink .= getBitstreamSize($bitstream);
-                    $bitstreamLink .= '</span></p>'; */
                     $bitstreamLink .= '</div>';
 
                     $mainImage = true;
@@ -106,33 +104,14 @@ if(isset($solr[$type_field])) {
                 }
                 else {
 
-                    if(isset($doc[$thumbnail_field])) {
-                        $thumbnail = $doc[$thumbnail_field][0];
+                    $t_uri = $b_uri . '.jpg';
 
-                        $t_segments = explode("##", $thumbnail);
-                        $t_filename = $t_segments[1];
-                        $t_handle = $t_segments[3];
-                        $t_seq = $t_segments[4];
-                        $t_handle_id = preg_replace('/^.*\//', '',$t_handle);
-                        $t_uri = './record/'.$t_handle_id.'/'.$t_seq.'/'.$t_filename;
-
-                        $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-                        if($numThumbnails == 0 || $numThumbnails == 4) {
-                            $thumbnailLink[$numThumbnails] .= ' first';
-                        }
-                        $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $t_uri . '> ';
-                        $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-
+                    $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
+                    if($numThumbnails % 4 === 0) {
+                        $thumbnailLink[$numThumbnails] .= ' first';
                     }
-                    else {
-
-                        $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-                        if($numThumbnails == 0 || $numThumbnails == 4) {
-                            $thumbnailLink[$numThumbnails] .= ' first';
-                        }
-                        $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href=' . $b_uri . '> ';
-                        $thumbnailLink[$numThumbnails] .= '<img src = "'.$b_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-                    }
+                    $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $t_uri . '"> ';
+                    $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
 
                     $numThumbnails++;
 
@@ -166,13 +145,35 @@ if(isset($solr[$type_field])) {
             echo '<div class="clearfix"></div>';
         }
 
+        $i = 0;
+        $newStrip = false;
         if($numThumbnails > 0) {
 
             echo '<div class="thumbnail-strip">';
 
             foreach($thumbnailLink as $thumb) {
-                echo $thumb;
+
+                if($newStrip)
+                {
+
+                    echo '</div><div class="clearfix"></div>';
+                    echo '<div class="thumbnail-strip">';
+                    echo $thumb;
+                    $newStrip = false;
+                }
+                else {
+
+                    echo $thumb;
+                }
+
+                $i++;
+
+                // if we're starting a new thumbnail strip
+                if($i % 4 === 0) {
+                    $newStrip = true;
+                }
             }
+
             echo '</div><div class="clearfix"></div>';
         }
 

--- a/theme/mimed/views/search_results.php
+++ b/theme/mimed/views/search_results.php
@@ -147,13 +147,13 @@
                             $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
                             $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
 
+                            //todo check as assumes there is always a thumbnail for a jpg and only jpgs
                             if (!$firstImg && strpos($b_uri, ".jpg") > 0)
                             {
                                 $firstImg = true;
-                                //todo check as assumes there is always a thumbnail for a jpg
                                 $t_uri = $b_uri . '.jpg';
 
-                                $thumbnailLink = '<a title = "' . $doc[$title_field][0] . '" class="fancybox" rel="group' . $j . '" href=' . $b_uri . '> ';
+                                $thumbnailLink = '<a title = "' . $doc[$title_field][0] . '" class="fancybox" rel="group' . $j . '" href="' . $b_uri . '"> ';
                                 $thumbnailLink .= '<img src = "'.$t_uri.'" class="search-thumbnail" title="'. $doc[$title_field][0] .'" /></a>';
 
                                 echo $thumbnailLink;


### PR DESCRIPTION
- Added in inverted commas for href of bitstreamLink which resolved issues with file names with spaces
- Split thumbnail strip into 4 thumbnails per strip with a clear fix div after each to stop shorter thumbnails causing problems with float lefts.
