### PR TITLE
LIB001-1768 Microsoft Edge video problem

### DIFF
--- a/config/iconics.php
+++ b/config/iconics.php
@@ -13,16 +13,16 @@ $config['skylight_adminemail'] = 'lddt@mlist.is.ed.ac.uk';
 
 $config['skylight_oaipmhcollection'] = 'hdl_10683_117182';
 
-// set ga code
+// set ga code and dspace collection id
 if (strpos($_SERVER['HTTP_HOST'], "test") !== false) {
     $config['skylight_ga_code'] = 'UA-25737241-6';
+    $config['skylight_container_id'] = '48';
 }
 else {
     $config['skylight_ga_code'] = 'UA-25737241-9';
+    $config['skylight_container_id'] = '30';
 }
 
-// Container ID and the field used in solr index to store this ID. Used for restricting search/browse scope.
-$config['skylight_container_id'] = '30';
 $config['skylight_container_field'] = 'location.coll';
 
 $config['skylight_fields'] = array('Title' => 'dc.title.en',

--- a/static/exhibitions/somethingblue.php
+++ b/static/exhibitions/somethingblue.php
@@ -11,14 +11,31 @@
         </div>
 
 
+        <?php
 
-<?php
+        $mp4ok = false;
+        // Use MP4 for all browsers other than Chrome
+        if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+        {
+            $mp4ok = true;
+        }
+        //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+        else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+        {
+            $mp4ok = true;
+        }
+        else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false) {
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
+                $mp4ok = false;
+            }
+        }
+
         $record_title = 'Something Blue Introduction';
         $b_filename = base_url().'videos/0051014v-001.';
         $b_seq = 0;
         $videoLink = "";
 
-        if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+        if ($mp4ok == true) {
             $videoLink = '<div class="flowplayer"  title="' . $record_title . '">';
             $videoLink .= '<video id="video-' . $b_seq. '" title="' . $record_title . '" ';
             $videoLink .= 'controls preload="true" width="660">';

--- a/static/exhibitions/towardsdolly.php
+++ b/static/exhibitions/towardsdolly.php
@@ -7,16 +7,35 @@
         </div>
 
         <?php
+
+        $mp4ok = false;
+        // Use MP4 for all browsers other than Chrome
+        if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+        {
+            $mp4ok = true;
+        }
+        //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+        else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+        {
+            $mp4ok = true;
+        }
+        else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false) {
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
+                $mp4ok = false;
+            }
+        }
+
         $record_title = 'Towards Dolly Introduction';
         $b_filename = base_url().'videos/0051018v-004.';
+        $b_uri = $b_filename.'mp4';
         $b_seq = 0;
         $videoLink = "";
 
-        if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+        if ($mp4ok == true) {
             $videoLink = '<div class="flowplayer"  title="' . $record_title . '">';
             $videoLink .= '<video id="video-' . $b_seq. '" title="' . $record_title . '" ';
             $videoLink .= 'controls preload="true" width="660">';
-            $videoLink .= '<source src="' . $b_filename . 'mp4" type="video/mp4" />Video loading...';
+            $videoLink .= '<source src="' . $b_uri.'" type="video/mp4" />Video loading...';
             $videoLink .= '</video>';
             $videoLink .= '</div>';
             echo $videoLink;

--- a/static/towardsdolly/about.php
+++ b/static/towardsdolly/about.php
@@ -1,3 +1,21 @@
+<?php
+    $mp4ok = false;
+    // Use MP4 for all browsers other than Chrome
+    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+    {
+        $mp4ok = true;
+    }
+    //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+    else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+    {
+        $mp4ok = true;
+    }
+    else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false) {
+        if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
+            $mp4ok = false;
+        }
+    }
+?>
 <div class="content">
     <div class="content byEditor">
         <p>Since 2012, the Wellcome Trust has funded a number of projects relating to animal genetics collections held
@@ -25,7 +43,7 @@
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Introduction to Towards Dolly by Clare Button, Project Archivist">
             <video id="video-archives" title="Introduction to Towards Dolly by Clare Button, Project Archivist" controls preload="true">
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok = true) {?>
                     <source src="<?php echo base_url(); ?>videos/Towards_Dolly_Wellcome_Trust_showreel.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/Towards_Dolly_Wellcome_Trust_showreel.webm" type="video/webm"/>
@@ -45,8 +63,7 @@
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Towards Dolly Exhibition being installed, Video by Univeristy of Edinburgh Digital Imaging Unit"">
             <video id="video-archives" title="Towards Dolly Exhibition being installed, Video by Univeristy of Edinburgh Digital Imaging Unit" controls preload="true">
-
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok = true) {?>
                     <source src="<?php echo base_url(); ?>videos/0051021v-001.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/0051021v-001.webm" type="video/webm"/>

--- a/theme/alumni/views/record.php
+++ b/theme/alumni/views/record.php
@@ -7,6 +7,7 @@ $subject_field = $this->skylight_utilities->getField("Subject");
 $uri_field = $this->skylight_utilities->getField("Link");
 $filters = array_keys($this->config->item("skylight_filters"));
 $static_page = $this->config->item("skylight_static_pages");
+$media_uri = $this->config->item("skylight_media_url_prefix");
 
 
 $type = 'Unknown';
@@ -40,195 +41,6 @@ if(isset($solr[$type_field])) {
 </div>
 
 <div class="content">
-    <?php if(isset($solr[$bitstream_field]) && $link_bitstream) { ?>
-
-        <div class="record_bitstreams"><?php
-
-        $mainImage = false;
-        $videoFile = false;
-        $audioFile = false;
-        $audioLink = "";
-        $videoLink = "";
-
-        foreach ($solr[$bitstream_field] as $bitstream)
-        {
-            $b_segments = explode("##", $bitstream);
-            $b_filename = $b_segments[1];
-            $b_seq = $b_segments[4];
-
-            if((strpos($b_filename, ".jpg") > 0) || (strpos($b_filename, ".JPG") > 0)) {
-
-                $bitstream_array[$b_seq] = $bitstream;
-
-            }
-        }
-
-        // sorting array so main image is first
-        ksort($bitstream_array);
-
-        $b_seq =  "";
-
-        foreach($bitstream_array as $bitstream) {
-
-            $b_segments = explode("##", $bitstream);
-            $b_filename = $b_segments[1];
-            $b_handle = $b_segments[3];
-            $b_seq = $b_segments[4];
-            $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
-            $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-
-            if ((strpos($b_uri, ".jpg") > 0) or (strpos($b_uri, ".JPG") > 0))
-            {
-                // is there a main image
-                if (!$mainImage) {
-
-                    $bitstreamLink = '<div class="main-image">';
-
-                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
-                    $bitstreamLink .= '<img class="record-main-image" src = "'. $b_uri .'">';
-                    $bitstreamLink .= '</a>';
-
-                    $bitstreamLink .= '</div>';
-
-                    $mainImage = true;
-
-                }
-                // we need to display a thumbnail
-                else {
-
-                    // if there are thumbnails
-                    if(isset($solr[$thumbnail_field])) {
-                        foreach ($solr[$thumbnail_field] as $thumbnail) {
-
-                            $t_segments = explode("##", $thumbnail);
-                            $t_filename = $t_segments[1];
-
-                            if ($t_filename === $b_filename . ".jpg") {
-
-                                $t_handle = $t_segments[3];
-                                $t_seq = $t_segments[4];
-                                $t_uri = './record/'.$b_handle_id.'/'.$t_seq.'/'.$t_filename;
-
-                                $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
-
-                                if($numThumbnails % 4 === 0) {
-                                    $thumbnailLink[$numThumbnails] .= ' first';
-                                }
-
-                                $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
-                                $thumbnailLink[$numThumbnails] .= '<img src = "'.$t_uri.'" class="record-thumbnail" title="'. $record_title .'" /></a></div>';
-
-                                $numThumbnails++;
-                            }
-                        }
-                    }
-
-                }
-
-            }
-            else if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0)) {
-
-                $audioLink .= '<audio controls>';
-                $audioLink .= '<source src="' . $b_uri . '" type="audio/mpeg" />Audio loading...';
-                $audioLink .= '</audio>';
-                $audioFile = true;
-
-            }
-
-            else if ((strpos($b_uri, ".mp4") > 0) or (strpos($b_uri, ".MP4") > 0))
-            {
-
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                    $videoLink .= '<video controls>';
-                    $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
-                    $videoLink .= '</video>';
-                    $videoLink .= '</div>';
-
-                    $videoFile = true;
-
-                }
-            }
-            else if ((strpos($b_uri, ".webm") > 0) or (strpos($b_uri, ".WEBM") > 0))
-            {
-
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                    $videoLink .= '<video controls>';
-                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                    $videoLink .= '</video>';
-                    $videoLink .= '</div>';
-
-                    $videoFile = true;
-
-                }
-            }
-
-            ?>
-        <?php
-        } // end for each bitstream
-
-
-        if($mainImage) {
-
-            echo $bitstreamLink;
-            echo '<div class="clearfix"></div>';
-        }
-
-        $i = 0;
-        $newStrip = false;
-        if($numThumbnails > 0) {
-
-            echo '<div class="thumbnail-strip">';
-
-            foreach($thumbnailLink as $thumb) {
-
-                if($newStrip)
-                {
-
-                    echo '</div><div class="clearfix"></div>';
-                    echo '<div class="thumbnail-strip">';
-                    echo $thumb;
-                    $newStrip = false;
-                }
-                else {
-
-                    echo $thumb;
-                }
-
-                $i++;
-
-                // if we're starting a new thumbnail strip
-                if($i % 4 === 0) {
-                    $newStrip = true;
-                }
-            }
-
-            echo '</div><div class="clearfix"></div>';
-        }
-
-        if($audioFile) {
-
-            echo $audioLink;
-        }
-
-        if($videoFile) {
-
-            echo $videoLink;
-        }
-
-        echo '</div><div class="clearfix"></div>';
-
-        }
-
-        echo '</div>';
-        ?>
-
-
     <table>
         <tbody>
         <?php foreach($recorddisplay as $key) {
@@ -272,37 +84,194 @@ if(isset($solr[$type_field])) {
 
         }
 
-        if(isset($solr[$uri_field])) {
-
-            foreach($solr[$uri_field] as $uri) {
-                $find   = 'http://hdl.handle.net';
-                $findLuna = 'http://images.is.ed.ac.uk';
-                $pos = strpos($uri, $find);
-
-                if ($pos === false)
-                {
-                    echo '<tr><th>Link</th><td>';
-                    $Lunapos = strpos($uri, $findLuna);
-
-                    if ($Lunapos !== false)
-                    {
-
-                        echo '<a href="'.$uri.'" title="Link to High resolution version of image" target="_blank">High resolution version of photo</a>';
-                    }
-                    else{
-                        echo '<a href="'.$uri.'" title="Link to '.$uri.'" target="_blank">'.$uri.'</a>';
-                    }
-                    if($index < sizeof($solr[$uri_field]) - 1) {
-                        echo '<br />';
-                    }
-                    echo '</td></tr>';
-                }
-            }
-        }
         ?>
         </tbody>
     </table>
+    <?php if(isset($solr[$bitstream_field]) && $link_bitstream) { ?>
 
+    <div class="record_bitstreams"><?php
+
+        $mainImage = false;
+        $videoFile = false;
+        $audioFile = false;
+        $audioLink = "";
+        $videoLink = "";
+
+        foreach ($solr[$bitstream_field] as $bitstream) {
+            $b_segments = explode("##", $bitstream);
+            $b_filename = $b_segments[1];
+            $b_seq = $b_segments[4];
+            $bitstream_array[$b_seq] = $bitstream;
+        }
+
+        // sorting array so main image is first
+        ksort($bitstream_array);
+
+        $b_seq = "";
+
+        foreach ($bitstream_array as $bitstream) {
+            $mp4ok = false;
+            $b_segments = explode("##", $bitstream);
+            $b_filename = $b_segments[1];
+            $b_handle = $b_segments[3];
+            $b_seq = $b_segments[4];
+            $b_handle_id = preg_replace('/^.*\//', '', $b_handle);
+            $b_uri = './record/' . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+
+
+            if ((strpos($b_uri, ".jpg") > 0) or (strpos($b_uri, ".JPG") > 0)) {
+                // is there a main image
+                if (!$mainImage) {
+
+                    $bitstreamLink = '<div class="main-image">';
+
+                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
+                    $bitstreamLink .= '<img class="record-main-image" src = "' . $b_uri . '">';
+                    $bitstreamLink .= '</a>';
+
+                    $bitstreamLink .= '</div>';
+
+                    $mainImage = true;
+
+                } // we need to display a thumbnail
+                else {
+
+                    // if there are thumbnails
+                    if (isset($solr[$thumbnail_field])) {
+                        foreach ($solr[$thumbnail_field] as $thumbnail) {
+
+                            $t_segments = explode("##", $thumbnail);
+                            $t_filename = $t_segments[1];
+
+                            if ($t_filename === $b_filename . ".jpg") {
+
+                                $t_handle = $t_segments[3];
+                                $t_seq = $t_segments[4];
+                                $t_uri = './record/' . $b_handle_id . '/' . $t_seq . '/' . $t_filename;
+
+                                $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
+
+                                if ($numThumbnails % 4 === 0) {
+                                    $thumbnailLink[$numThumbnails] .= ' first';
+                                }
+
+                                $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
+                                $thumbnailLink[$numThumbnails] .= '<img src = "' . $t_uri . '" class="record-thumbnail" title="' . $record_title . '" /></a></div>';
+
+                                $numThumbnails++;
+                            }
+                        }
+                    }
+
+                }
+
+            } else if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0)) {
+
+                $audioLink .= '<audio controls>';
+                $audioLink .= '<source src="' . $b_uri . '" type="audio/mpeg" />Audio loading...';
+                $audioLink .= '</audio>';
+                $audioFile = true;
+
+            } else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0)) {
+                $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                // Use MP4 for all browsers other than Chrome
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+                    $mp4ok = true;
+                } //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+                else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true) {
+                    $mp4ok = true;
+                }
+
+                if ($mp4ok == true) {
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
+            } else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0)) {
+                //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false) {
+                    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
+                        $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                        // if it's chrome, use webm if it exists
+                        $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                        $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                        $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                        $videoLink .= '</video>';
+                        $videoLink .= '</div>';
+                        $videoFile = true;
+                    }
+                }
+            }
+
+
+            ?>
+            <?php
+        } // end for each bitstream
+
+
+        if ($mainImage) {
+
+            echo $bitstreamLink;
+            echo '<div class="clearfix"></div>';
+        }
+
+    ?>
+
+
+
+
+        <?php
+        $i = 0;
+        $newStrip = false;
+        if($numThumbnails > 0) {
+
+        echo '<div class="thumbnail-strip">';
+
+            foreach($thumbnailLink as $thumb) {
+
+            if($newStrip)
+            {
+
+            echo '</div><div class="clearfix"></div>';
+        echo '<div class="thumbnail-strip">';
+            echo $thumb;
+            $newStrip = false;
+            }
+            else {
+
+            echo $thumb;
+            }
+
+            $i++;
+
+            // if we're starting a new thumbnail strip
+            if($i % 4 === 0) {
+            $newStrip = true;
+            }
+            }
+
+            echo '</div><div class="clearfix"></div>';
+        }
+
+        if($audioFile) {
+
+        echo $audioLink;
+        }
+
+        if($videoFile) {
+
+        echo $videoLink;
+        }
+
+        echo '</div><div class="clearfix"></div>';
+
+    }
+
+    echo '</div>';
+?>
     <input type="button" value="Back to Search Results" class="backbtn" onClick="history.go(-1);">
 
 

--- a/theme/anatomy/views/record.php
+++ b/theme/anatomy/views/record.php
@@ -37,7 +37,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         $b_handle = $b_segments[3];
@@ -108,34 +108,44 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto  loop width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
 

--- a/theme/art/views/record.php
+++ b/theme/art/views/record.php
@@ -39,7 +39,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if($image_id == "") {
@@ -113,36 +113,47 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto  loop width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto  loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
+
         else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0)) {
 
             $bitstreamLink = $this->skylight_utilities->getBitstreamLink($bitstream);

--- a/theme/audio/views/record.php
+++ b/theme/audio/views/record.php
@@ -17,9 +17,10 @@ $numThumbnails = 0;
 $bitstreamLinks = array();
 $image_id = "";
 
+echo 'feckthelotoyis';
 
 if(isset($solr[$bitstream_field]) && $link_bitstream) {
-
+    echo 'I am in here';
     foreach ($solr[$bitstream_field] as $bitstream_for_array)
     {
         $b_segments = explode("##", $bitstream_for_array);
@@ -37,7 +38,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if($image_id == "") {
@@ -47,7 +48,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         $b_seq = $b_segments[4];
         $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
         $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-
+        echo 'BITSTREAM'.$b_uri;
         if ((strpos($b_uri, ".jpg") > 0) or (strpos($b_uri, ".JPG") > 0))
         {
             if (!$mainImage) {
@@ -101,6 +102,8 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         }
         else if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0)) {
 
+            echo 'in here'.$b_uri;
+
             $audioLink .= '<audio id="audio-' . $b_seq;
             $audioLink .= '" title="' . $record_title . ": " . $b_filename . '" ';
             $audioLink .= 'controls preload="true" width="600">';
@@ -113,36 +116,47 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto  loop width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
+
         else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0)) {
 
             $bitstreamLink = $this->skylight_utilities->getBitstreamLink($bitstream);

--- a/theme/calendars/views/record.php
+++ b/theme/calendars/views/record.php
@@ -69,7 +69,7 @@ if(isset($solr[$type_field])) {
         $b_seq =  "";
 
         foreach($bitstream_array as $bitstream) {
-
+            $mp4ok = false;
             $b_segments = explode("##", $bitstream);
             $b_filename = $b_segments[1];
             $b_handle = $b_segments[3];
@@ -138,34 +138,44 @@ if(isset($solr[$type_field])) {
             else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
             {
                 $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+                // Use MP4 for all browsers other than Chrome
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+                {
+                    $mp4ok = true;
+                }
+                //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+                else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+                {
+                    $mp4ok = true;
+                }
 
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls>';
+                if ($mp4ok == true)
+                {
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                     $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                     $videoLink .= '</video>';
                     $videoLink .= '</div>';
                     $videoFile = true;
-
                 }
             }
+
             else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
             {
-
-                $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                    $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                    $videoLink .= '</video>';
-                    $videoLink .= '</div>';
-
-                    $videoFile = true;
-
+                //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+                {
+                    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                    {
+                        $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                        // if it's chrome, use webm if it exists
+                        $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                        $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                        $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                        $videoLink .= '</video>';
+                        $videoLink .= '</div>';
+                        $videoFile = true;
+                    }
                 }
             }
 

--- a/theme/clds/views/result_type_header.php
+++ b/theme/clds/views/result_type_header.php
@@ -1,5 +1,21 @@
 <?php
-        //echo $search_url;
+    $mp4ok = false;
+    // Use MP4 for all browsers other than Chrome
+    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+    {
+        $mp4ok = true;
+    }
+    //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+    else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+    {
+        $mp4ok = true;
+    }
+    else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false) {
+        if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
+            $mp4ok = false;
+        }
+    }
+//echo $search_url;
         if (!empty($search_url))
 {
 
@@ -15,7 +31,7 @@ if (strpos($search_url, 'Header:%22archives%22') > 0)
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Introduction to Archives by Archives Manager, Rachel Hosker">
             <video id="video-archives" title="Introduction to Archives by Archives Manager, Rachel Hosker" controls preload="true">
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok == true) { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-006.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-006.webm" type="video/webm"/>
@@ -40,7 +56,7 @@ if (strpos($search_url, 'Header:%22archives%22') > 0)
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Introduction to Museums by Head of Museums, Jacky MacBeath">
             <video id="video-museums" title="Introduction to Museums by Head of Museums, Jacky MacBeath" controls preload="true">
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok == true)  { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-004.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-004.webm" type="video/webm"/>
@@ -62,11 +78,12 @@ if (strpos($search_url, 'Header:%22archives%22') > 0)
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Introduction to Rare Books by Head of Special Collections, Joseph Marshall">
             <video id="video-rarebooks" title="Introduction to Rare Books by Head of Special Collections, Joseph Marshall" controls preload="true">
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok == true) { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-005.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-005.webm" type="video/webm"/>
-                <?php } ?>
+                <?php }?>
+
                 Video loading...'
             </video>
         </div>
@@ -84,7 +101,7 @@ if (strpos($search_url, 'Header:%22archives%22') > 0)
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Introduction to the Art Collections by Curator Neil Lebeter">
             <video id="video-art" title="Introduction to the Art Collections by Curator Neil Lebeter" controls preload="true">
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok == true) { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-001.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-001.webm" type="video/webm"/>
@@ -108,7 +125,7 @@ if (strpos($search_url, 'Header:%22archives%22') > 0)
         <div class="flowplayer" data-analytics="<?php echo $ga_code ?>"
              title="Introduction to MIMEd by MIMEd Pricipal Curator, Darryl Martin">
             <video id="video-mimed" title="Introduction to MIMEd by MIMEd Pricipal Curator, Darryl Martin" controls preload="true">
-                <?php if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) { ?>
+                <?php if ($mp4ok == true) { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-002.mp4" type="video/mp4"/>
                 <?php } else { ?>
                     <source src="<?php echo base_url(); ?>videos/0051011v-002.webm" type="video/webm"/>

--- a/theme/default/views/record.php
+++ b/theme/default/views/record.php
@@ -121,7 +121,7 @@ ksort($bitstream_array);
     //SR JIRA001-665 sort bitstreams by sequence to ensure they show in correct order
     //foreach($solr[$bitstream_field] as $bitstream) {
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         $b_handle = $b_segments[3];
@@ -172,38 +172,47 @@ ksort($bitstream_array);
 
         }
 
-        else if ((strpos($b_uri, ".mp4") > 0) or (strpos($b_uri, ".MP4") > 0))
+        else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
+            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
-
+            if ($mp4ok == true)
+            {
                 $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video id="video-' . $b_seq. '" title="' . $record_title . ": " . $b_filename . '" ';
-                $videoLink .= 'controls preload="true" width="600">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
-
                 $videoFile = true;
-
             }
         }
-        else if ((strpos($b_uri, ".webm") > 0) or (strpos($b_uri, ".WEBM") > 0))
+
+        else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video id="video-' . $b_seq. '" title="' . $record_title . ": " . $b_filename . '" ';
-                $videoLink .= 'controls preload="none" width="600">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
 

--- a/theme/exhibitions/views/record.php
+++ b/theme/exhibitions/views/record.php
@@ -40,7 +40,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if($image_id == "") {
@@ -102,46 +102,48 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
             }
 
         }
-        else if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0))  {
-
-            $audioLink .= '<audio controls>';
-            $audioLink .= '<source src="' . $b_uri . '" type="audio/mpeg" />Audio loading...';
-            $audioLink .= '</audio>';
-            $audioFile = true;
-
-        }
 
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
 

--- a/theme/iconics/views/record.php
+++ b/theme/iconics/views/record.php
@@ -45,7 +45,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         $image_id = substr($b_filename,0,7);
@@ -117,34 +117,44 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
 

--- a/theme/iconicsdeepzoom/views/record.php
+++ b/theme/iconicsdeepzoom/views/record.php
@@ -45,7 +45,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if (strpos($b_filename, "-")> 0)
@@ -80,22 +80,6 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
                 </script>
                     </id>
                 <?php
-                /*
-                }
-                else {
-                    // we have a main image
-                    $mainImageTest = true;
-
-                    $bitstreamLink = '<div class="main-image">';
-
-                    $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
-                    $bitstreamLink .= '<img class="record-main-image" src = "' . $b_uri . '">';
-                    $bitstreamLink .= '</a>';
-
-                    $bitstreamLink .= '</div>';
-
-                    $mainImage = true;
-                }*/
 
             }
             // we need to display a thumbnail
@@ -131,6 +115,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
             }
 
         }
+
         else if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0)) {
 
             $audioLink .= '<audio controls>';
@@ -140,39 +125,49 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
         }
 
-        else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
-        {
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
+            {
+                $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
+                // Use MP4 for all browsers other than Chrome
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+                {
+                    $mp4ok = true;
+                }
+                //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+                else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+                {
+                    $mp4ok = true;
+                }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto autoplay loop width="100%" height="auto" controls>';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-                $videoFile = true;
-
+                if ($mp4ok == true)
+                {
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
-        }
-        else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
-        {
 
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto autoplay loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
+            {
+                //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+                {
+                    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                    {
+                        $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                        // if it's chrome, use webm if it exists
+                        $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                        $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                        $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                        $videoLink .= '</video>';
+                        $videoLink .= '</div>';
+                        $videoFile = true;
+                    }
+                }
             }
-        }
 
         ?>
     <?php

--- a/theme/mimed/views/record.php
+++ b/theme/mimed/views/record.php
@@ -39,6 +39,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
     foreach($bitstream_array as $bitstream) {
 
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         $b_handle = $b_segments[3];
@@ -83,34 +84,44 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
                 $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
 

--- a/theme/openbooks/views/record.php
+++ b/theme/openbooks/views/record.php
@@ -1,4 +1,6 @@
 <?php
+
+
 $type_field = $this->skylight_utilities->getField("Type");
 $subject_field = $this->skylight_utilities->getField("Subject");
 $uri_field = $this->skylight_utilities->getField("Link");
@@ -133,7 +135,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         $b_handle = $b_segments[3];
@@ -178,36 +180,47 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
                 $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
+
         else if ((strpos($b_filename, ".pdf") > 0) or (strpos($b_filename, ".PDF") > 0))
         {
             $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;

--- a/theme/piccolo/views/record.php
+++ b/theme/piccolo/views/record.php
@@ -37,7 +37,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if($image_id == "") {
@@ -111,36 +111,47 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-
-                $videoFile = true;
-
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
+
         else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0)) {
 
             $bitstreamLink = $this->skylight_utilities->getBitstreamLink($bitstream);

--- a/theme/projects/views/record.php
+++ b/theme/projects/views/record.php
@@ -100,6 +100,7 @@ $bitstreamLinks = array();
 
         foreach($bitstream_array as $bitstream) {
 
+            $mp4ok = false;
             $b_segments = explode("##", $bitstream);
             $b_filename = $b_segments[1];
             $b_handle = $b_segments[3];
@@ -165,36 +166,47 @@ $bitstreamLinks = array();
 
             }
 
-            else if ((strpos($b_uri, ".mp4") > 0) or (strpos($b_uri, ".MP4") > 0))
+            else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
             {
+                $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
+                // Use MP4 for all browsers other than Chrome
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+                {
+                    $mp4ok = true;
+                }
+                //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+                else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+                {
+                    $mp4ok = true;
+                }
 
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
-
+                if ($mp4ok == true)
+                {
                     $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                    $videoLink .= '<video controls>';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                     $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                     $videoLink .= '</video>';
                     $videoLink .= '</div>';
-
                     $videoFile = true;
-
                 }
             }
-            else if ((strpos($b_uri, ".webm") > 0) or (strpos($b_uri, ".WEBM") > 0))
+
+            else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
             {
-
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                    $videoLink .= '<video controls>';
-                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                    $videoLink .= '</video>';
-                    $videoLink .= '</div>';
-
-                    $videoFile = true;
-
+                //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+                {
+                    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                    {
+                        $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                        // if it's chrome, use webm if it exists
+                        $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                        $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                        $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                        $videoLink .= '</video>';
+                        $videoLink .= '</div>';
+                        $videoFile = true;
+                    }
                 }
             }
 

--- a/theme/rocks/views/record.php
+++ b/theme/rocks/views/record.php
@@ -94,7 +94,7 @@ if(isset($solr[$type_field])) {
         $b_seq =  "";
 
         foreach($bitstream_array as $bitstream) {
-
+            $mp4ok = false;
             $b_segments = explode("##", $bitstream);
             $b_filename = $b_segments[1];
             $b_handle = $b_segments[3];
@@ -163,34 +163,44 @@ if(isset($solr[$type_field])) {
             else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
             {
                 $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+                // Use MP4 for all browsers other than Chrome
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+                {
+                    $mp4ok = true;
+                }
+                //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+                else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+                {
+                    $mp4ok = true;
+                }
 
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls>';
+                if ($mp4ok == true)
+                {
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                     $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                     $videoLink .= '</video>';
                     $videoLink .= '</div>';
                     $videoFile = true;
-
                 }
             }
+
             else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
             {
-
-                $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-                // if it's chrome, use webm if it exists
-                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                    $videoLink .= '<video preload=auto loop width="100%" height="auto">';
-                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                    $videoLink .= '</video>';
-                    $videoLink .= '</div>';
-
-                    $videoFile = true;
-
+                //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+                {
+                    if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                    {
+                        $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                        // if it's chrome, use webm if it exists
+                        $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                        $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                        $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                        $videoLink .= '</video>';
+                        $videoLink .= '</div>';
+                        $videoFile = true;
+                    }
                 }
             }
 

--- a/theme/sch/views/record.php
+++ b/theme/sch/views/record.php
@@ -42,7 +42,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if($image_id == "") {
@@ -102,31 +102,44 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto  width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-                $videoFile = true;
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
         else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0)) {

--- a/theme/stcecilia/views/record.php
+++ b/theme/stcecilia/views/record.php
@@ -42,7 +42,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     $b_seq =  "";
 
     foreach($bitstream_array as $bitstream) {
-
+        $mp4ok = false;
         $b_segments = explode("##", $bitstream);
         $b_filename = $b_segments[1];
         if($image_id == "") {
@@ -102,31 +102,44 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false) {
+            // Use MP4 for all browsers other than Chrome
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == false)
+            {
+                $mp4ok = true;
+            }
+            //Microsoft Edge is calling itself Chrome, Mozilla and Safari, as well as Edge, so we need to deal with that.
+            else if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == true)
+            {
+                $mp4ok = true;
+            }
 
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $b_filename . '">';
-                $videoLink .= '<video preload=auto width="100%" height="auto" controls>';
+            if ($mp4ok == true)
+            {
+                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
                 $videoLink .= '<source src="' . $b_uri . '" type="video/mp4" />Video loading...';
                 $videoLink .= '</video>';
                 $videoLink .= '</div>';
                 $videoFile = true;
-
             }
         }
+
         else if ((strpos($b_filename, ".webm") > 0) or (strpos($b_filename, ".WEBM") > 0))
         {
-
-            $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
-            // if it's chrome, use webm if it exists
-            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true) {
-
-                $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
-                $videoLink .= '<video preload=auto  width="100%" height="auto">';
-                $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
-                $videoLink .= '</video>';
-                $videoLink .= '</div>';
-                $videoFile = true;
+            //Microsoft Edge needs to be dealt with. Chrome calls itself Safari too, but that doesn't matter.
+            if (strpos($_SERVER['HTTP_USER_AGENT'], 'Edge') == false)
+            {
+                if (strpos($_SERVER['HTTP_USER_AGENT'], 'Chrome') == true)
+                {
+                    $b_uri = $media_uri . $b_handle_id . '/' . $b_seq . '/' . $b_filename;
+                    // if it's chrome, use webm if it exists
+                    $videoLink .= '<div class="flowplayer" data-analytics="' . $ga_code . '" title="' . $record_title . ": " . $b_filename . '">';
+                    $videoLink .= '<video preload=auto loop width="100%" height="auto" controls preload="true" width="660">';
+                    $videoLink .= '<source src="' . $b_uri . '" type="video/webm" />Video loading...';
+                    $videoLink .= '</video>';
+                    $videoLink .= '</div>';
+                    $videoFile = true;
+                }
             }
         }
         else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0)) {


### PR DESCRIPTION
(used branch LIB001-1765, but should not matter once pull request done)

updated the following record.php files to allow Edge to play MP4 and not default to WEBM:
theme/alumni/views/record.php (new video capability confirmed)
theme/anatomy/views/record.php
theme/art/views/record.php
theme/audio/views/record.php
theme/calendars/views/record.php
theme/clds/views/record.php (new video capability confirmed within the record, also fixed for dodgy display when no bitstream attached)
theme/default/views/record.php
theme/exhibitions/views/record.php
theme/iconics/views/record.php
theme/iconicsdeepzoom/views/record.php
theme/mimed/views/record.php
theme/openbooks/views/record.php (new video capability confirmed)
theme/physics/views/record.php
theme/piccolo/views/record.php
theme/projects/views/record.php
theme/rocks/views/record.php
theme/sch/views/record.php
theme/stcecilias/views/record.php

The following static pages were updated:
static/exhibitions/towardsdolly.php
static/exhibitions/somethingblue.php
static/towardsdolly/about.php

Also this was updated:
theme/clds/views/result_type_header.php

Finally, I threw in a fix to allow 
config/iconics.php to pick up the right collection whether in test or live