### PR TITLE
LIB001-1700 First IIIF for Art

### DIFF
--- a/theme/art/views/header.php
+++ b/theme/art/views/header.php
@@ -48,6 +48,10 @@
         <script src="<?php echo base_url()?>assets/bootstrap/js/bootstrap.min.js"></script>
         <script src="<?php echo base_url()?>assets/jquery-1.11.0/jcarousel/jquery.jcarousel.min.js"></script>
         <script src="http://www.google-analytics.com/analytics.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
+        <script src="https://cdn.rawgit.com/mejackreed/Leaflet-IIIF/master/leaflet-iiif.js"></script>
+        <script src="<?php echo base_url()?>assets/openseadragon/openseadragon.min.js"></script>
+        <script type="text/javascript" src="//code.jquery.com/jquery-1.10.1.js"></script>
 
         <!-- Google Analytics -->
         <script>

--- a/theme/art/views/record.php
+++ b/theme/art/views/record.php
@@ -11,6 +11,7 @@ $tags_field = $this->skylight_utilities->getField("Tags");
 $media_uri = $this->config->item("skylight_media_url_prefix");
 
 $type = 'Unknown';
+$mainImage = false;
 $mainImageTest = false;
 $numThumbnails = 0;
 $bitstreamLinks = array();
@@ -20,35 +21,12 @@ if(isset($solr[$type_field])) {
     $type = "media-" . strtolower(str_replace(' ','-',$solr[$type_field][0]));
 }
 
-if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
-    foreach ($solr[$bitstream_field] as $bitstream_for_array)
-    {
-        $b_segments = explode("##", $bitstream_for_array);
-        $b_seq = $b_segments[4];
-        $bitstream_array[$b_seq] = $bitstream_for_array;
-    }
+// we need to display a thumbnail
 
-    ksort($bitstream_array);
 
-    $mainImage = false;
-    $videoFile = false;
-    $audioFile = false;
-    $audioLink = "";
-    $videoLink = "";
-    $b_seq =  "";
+/*
 
-    foreach($bitstream_array as $bitstream) {
-        $mp4ok = false;
-        $b_segments = explode("##", $bitstream);
-        $b_filename = $b_segments[1];
-        if($image_id == "") {
-            $image_id = substr($b_filename,0,7);
-        }
-        $b_handle = $b_segments[3];
-        $b_seq = $b_segments[4];
-        $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
-        $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
 
         if ((strpos($b_uri, ".jpg") > 0) or (strpos($b_uri, ".JPG") > 0))
         {
@@ -65,42 +43,10 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
                                 $bitstreamLink .= '</div>';
                         */
-                if (isset($solr[$link_uri_field]))
-                {
-                    foreach($solr[$link_uri_field] as $linkURI) {
-                        if (strpos($linkURI, 'luna') > 0) {
-                            //just for test, this line!
-                            $tileSource = str_replace('images.is.ed.ac.uk', 'images-test.is.ed.ac.uk:8181', $linkURI);
-                            $tileSource = str_replace('detail', 'iiif', $tileSource) . '/info.json';
-                        }
-                    }
-                }
 
-                echo' <div id="openseadragon1" style="width: 500px; height: 500px;"><script type="text/javascript">
-                OpenSeadragon({
-                    id:                 "openseadragon1",
-                    prefixUrl:          "assets/openseadragon/images/",
-                    preserveViewport:   true,
-                    visibilityRatio:    1,
-                    minZoomLevel:       1,
-                    defaultZoomLevel:   1,
-                    sequenceMode:       true,
-                    tileSources:        "'.$tileSource.'"
-
-                });
-                </script></div>';
-
-                                $mainImage = true;
-
-
-
-
-
-            }
-            // we need to display a thumbnail
-            else {
 
                 // if there are thumbnails
+/*
                 if(isset($solr[$thumbnail_field])) {
                     foreach ($solr[$thumbnail_field] as $thumbnail) {
 
@@ -129,16 +75,46 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
             }
 
-        }
-        else if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0)) {
+        }*/
+if(isset($solr[$bitstream_field]) && $link_bitstream)
+{
 
+    foreach ($solr[$bitstream_field] as $bitstream_for_array)
+    {
+        $b_segments = explode("##", $bitstream_for_array);
+        $b_seq = $b_segments[4];
+        $bitstream_array[$b_seq] = $bitstream_for_array;
+    }
+
+    ksort($bitstream_array);
+
+    $mainImage = false;
+    $videoFile = false;
+    $audioFile = false;
+    $audioLink = "";
+    $videoLink = "";
+    $b_seq =  "";
+
+    foreach($bitstream_array as $bitstream)
+    {
+        $mp4ok = false;
+        $b_segments = explode("##", $bitstream);
+        $b_filename = $b_segments[1];
+        if($image_id == "")
+        {
+            $image_id = substr($b_filename,0,7);
+        }
+        $b_handle = $b_segments[3];
+        $b_seq = $b_segments[4];
+        $b_handle_id = preg_replace('/^.*\//', '',$b_handle);
+        $b_uri = './record/'.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
+        if ((strpos($b_uri, ".mp3") > 0) or (strpos($b_uri, ".MP3") > 0))
+        {
             $audioLink .= '<audio controls>';
             $audioLink .= '<source src="' . $b_uri . '" type="audio/mpeg" />Audio loading...';
             $audioLink .= '</audio>';
             $audioFile = true;
-
         }
-
         else if ((strpos($b_filename, ".mp4") > 0) or (strpos($b_filename, ".MP4") > 0))
         {
             $b_uri = $media_uri.$b_handle_id.'/'.$b_seq.'/'.$b_filename;
@@ -183,26 +159,24 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
             }
         }
 
-        else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0)) {
+        else if ((strpos($b_uri, ".pdf") > 0) or (strpos($b_uri, ".PDF") > 0))
+        {
 
             $bitstreamLink = $this->skylight_utilities->getBitstreamLink($bitstream);
             $bitstreamUri = $this->skylight_utilities->getBitstreamUri($bitstream);
-
             $pdfLink .= 'Click ' . $bitstreamLink . 'to download. (<span class="bitstream_size">' . getBitstreamSize($bitstream) . '</span>)';
         }
 
         ?>
     <?php
     }
-
 }
 ?>
 
 <div class="content">
-
-    <?php if($mainImageTest === true) { ?>
+    <?php //if($mainImageTest === true) { ?>
     <div class="full-title">
-        <?php } ?>
+        <?php //} ?>
         <h1 class="itemtitle"><?php echo $record_title ?>
             <?php if(isset($solr[$date_field])) {
                 echo " (" . $solr[$date_field][0] . ")";
@@ -225,19 +199,91 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
             ?>
         </div>
-        <?php if($mainImageTest === true) { ?>
+        <?php //if($mainImageTest === true) { ?>
     </div>
-<?php if($mainImage) { ?>
-    <div class="full-image">
-        <?php echo $bitstreamLink; ?>
-    </div>
-<?php } ?>
-<?php } ?>
+<?php //if($mainImage) { ?>
 
-    <?php if($mainImageTest === true) { ?>
+        <?php //echo $bitstreamLink;
+        //if (isset($solr[$link_uri_field])) {
+        $numThumbnails = 0;
+        foreach ($solr[$link_uri_field] as $linkURI)
+        {
+            if (strpos($linkURI, 'luna') > 0)
+            {
+                //just for test, this line!
+                $tileSource = str_replace('images.is.ed.ac.uk', 'lac-luna-test2.is.ed.ac.uk:8181', $linkURI);
+                $tileSource = str_replace('detail', 'iiif', $tileSource) . '/info.json';
+                $iiifmax = str_replace('info.json', 'full/full/0/default.jpg', $tileSource);
+                list($width, $height) = getimagesize($iiifmax);
+                //echo 'WIDTH'.$width.'HEIGHT'.$height;
+
+
+                if (!$mainImage)
+                {
+
+                    $mainImageTest = true;
+                ?>
+                    <div class="full-image">
+                        <div id="openseadragon1" style="width: 660px; height:660px;">
+                            <script type="text/javascript">
+                                OpenSeadragon({
+                                    id: "openseadragon1",
+                                    prefixUrl: "<?php echo base_url();?>assets/openseadragon/images/",
+                                    preserveViewport: true,
+                                    visibilityRatio: 1,
+                                    minZoomLevel: 1,
+                                    defaultZoomLevel: 1,
+                                    sequenceMode: true,
+                                    tileSources: "<?php echo $tileSource;?>"
+
+                                });
+                            </script>
+                        </div>
+                    </div>
+                <?php
+                    $mainImage = true;
+                    $iiifurlsmall = str_replace('info.json', '1300,500,500,500/250,250/0/default.jpg', $tileSource);
+                    $iiifurlfull = str_replace('info.json', 'full/!660,660/0/default.jpg', $tileSource);
+
+                    $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
+
+                    if ($numThumbnails % 4 === 0)
+                    {
+                        $thumbnailLink[$numThumbnails] .= ' first';
+                    }
+
+                    $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $iiifurlfull . '"> ';
+                    $thumbnailLink[$numThumbnails] .= '<img src = "' . $iiifurlsmall . '" class="record-thumbnail" title="' . $record_title . '" /></a></div>';
+                }
+                else
+                {
+                    $iiifurlsmall = str_replace('info.json', '1300,500,500,500/250,250/0/default.jpg', $tileSource);
+                    $iiifurlfull = str_replace('info.json', 'full/!660,660/0/default.jpg', $tileSource);
+
+                    $thumbnailLink[$numThumbnails] = '<div class="thumbnail-tile';
+
+                    if ($numThumbnails % 4 === 0)
+                    {
+                        $thumbnailLink[$numThumbnails] .= ' first';
+                    }
+
+                    $thumbnailLink[$numThumbnails] .= '"><a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $iiifurlfull . '"> ';
+                    $thumbnailLink[$numThumbnails] .= '<img src = "' . $iiifurlsmall . '" class="record-thumbnail" title="' . $record_title . '" /></a></div>';
+
+
+                }
+                $numThumbnails++;
+            }
+        //}
+        } ?>
+
+<?php// } ?>
+<?php //} ?>
+
+    <?php //if($mainImageTest === true) { ?>
 
     <div class="full-metadata">
-        <?php } ?>
+        <?php// } ?>
         <table>
             <tbody>
             <?php $excludes = array(""); ?>
@@ -278,7 +324,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
             <?php
             $i = 0;
             $lunalink = false;
-            if (isset($solr[$link_uri_field])) {
+            /*if (isset($solr[$link_uri_field])) {
                 foreach($solr[$link_uri_field] as $linkURI) {
                     $linkURI = str_replace('"', '%22', $linkURI);
                     $linkURI = str_replace('|', '%7C', $linkURI);
@@ -301,12 +347,12 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
                 if($lunalink) {
                     echo '</td></tr>';
                 }
-            }?>
+            }*/?>
             </tbody>
         </table>
-        <?php if($mainImageTest === true) { ?>
+        <?php //if($mainImageTest === true) { ?>
     </div>
-<?php } ?>
+<?php// } ?>
     <div class="clearfix"></div>
     <!-- print out crowdsourced tags -->
     <?php
@@ -335,56 +381,54 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     else {
 
     ?>
-    <div class="crowd-tags">
-        <div class="crowd-info">
-            <form id="libraylabs" method="get" action="http://librarylabs.ed.ac.uk/games/gameCrowdSourcing.php" target="_blank">
-                <input type="hidden" name="image_id" value="<?php echo $image_id ?>">
-                <input type="hidden" name="theme" value="art">
-                Add tags to this image at <a href="#" onclick="document.forms[1].submit();return false;" title="University of Edinburgh, Library Labs Metadata Games">Library Labs Games</a>
-                (Create a login at <a href="https://www.ease.ed.ac.uk/friend/" target="_blank" title="EASE Friend">Edinburgh Friend Account</a>)
-            </form>
+        <div class="crowd-tags">
+            <div class="crowd-info">
+                <form id="libraylabs" method="get" action="http://librarylabs.ed.ac.uk/games/gameCrowdSourcing.php" target="_blank">
+                    <input type="hidden" name="image_id" value="<?php echo $image_id ?>">
+                    <input type="hidden" name="theme" value="art">
+                    Add tags to this image at <a href="#" onclick="document.forms[1].submit();return false;" title="University of Edinburgh, Library Labs Metadata Games">Library Labs Games</a>
+                    (Create a login at <a href="https://www.ease.ed.ac.uk/friend/" target="_blank" title="EASE Friend">Edinburgh Friend Account</a>)
+                </form>
+            </div>
         </div>
-    </div>
 
 
     <?php
     }
 
-    if(isset($solr[$bitstream_field]) && $link_bitstream) {
+    $i = 0;
+    $newStrip = false;
+    if($numThumbnails > 0) {
 
-        echo '<div class="record_bitstreams">';
+        echo '<div class="thumbnail-strip">';
 
-        $i = 0;
-        $newStrip = false;
-        if($numThumbnails > 0) {
+        foreach ($thumbnailLink as $thumb) {
 
-            echo '<div class="thumbnail-strip">';
+            if ($newStrip) {
 
-            foreach($thumbnailLink as $thumb) {
+                echo '</div><div class="clearfix"></div>';
+                echo '<div class="thumbnail-strip">';
+                echo $thumb;
+                $newStrip = false;
+            } else {
 
-                if($newStrip)
-                {
-
-                    echo '</div><div class="clearfix"></div>';
-                    echo '<div class="thumbnail-strip">';
-                    echo $thumb;
-                    $newStrip = false;
-                }
-                else {
-
-                    echo $thumb;
-                }
-
-                $i++;
-
-                // if we're starting a new thumbnail strip
-                if($i % 4 === 0) {
-                    $newStrip = true;
-                }
+                echo $thumb;
             }
 
-            echo '</div><div class="clearfix"></div>';
+            $i++;
+
+            // if we're starting a new thumbnail strip
+            if ($i % 4 === 0) {
+                $newStrip = true;
+            }
         }
+        echo '</div>';
+    }
+    echo '<div class="clearfix"></div>';
+
+    if(isset($solr[$bitstream_field]) && $link_bitstream)
+    {
+        echo '<div class="record_bitstreams">';
 
         if($audioFile) {
 
@@ -396,12 +440,12 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
 
             echo '<br>.<br>'.$videoLink;
         }
-
+        echo '</div>';
         echo '</div><div class="clearfix"></div>';
 
     }
 
-    echo '</div>';
+
     ?>
 
     <input type="button" value="Back to Search Results" class="backbtn" onClick="history.go(-1);">

--- a/theme/art/views/record.php
+++ b/theme/art/views/record.php
@@ -58,14 +58,43 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
                 $mainImageTest = true;
 
                 $bitstreamLink = '<div class="main-image">';
+                /*OLD CODE
+                                $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
+                                $bitstreamLink .= '<img class="record-main-image" src = "'. $b_uri .'">';
+                                $bitstreamLink .= '</a>';
 
-                $bitstreamLink .= '<a title = "' . $record_title . '" class="fancybox" rel="group" href="' . $b_uri . '"> ';
-                $bitstreamLink .= '<img class="record-main-image" src = "'. $b_uri .'">';
-                $bitstreamLink .= '</a>';
+                                $bitstreamLink .= '</div>';
+                        */
+                if (isset($solr[$link_uri_field]))
+                {
+                    foreach($solr[$link_uri_field] as $linkURI) {
+                        if (strpos($linkURI, 'luna') > 0) {
+                            //just for test, this line!
+                            $tileSource = str_replace('images.is.ed.ac.uk', 'images-test.is.ed.ac.uk:8181', $linkURI);
+                            $tileSource = str_replace('detail', 'iiif', $tileSource) . '/info.json';
+                        }
+                    }
+                }
 
-                $bitstreamLink .= '</div>';
+                echo' <div id="openseadragon1" style="width: 500px; height: 500px;"><script type="text/javascript">
+                OpenSeadragon({
+                    id:                 "openseadragon1",
+                    prefixUrl:          "assets/openseadragon/images/",
+                    preserveViewport:   true,
+                    visibilityRatio:    1,
+                    minZoomLevel:       1,
+                    defaultZoomLevel:   1,
+                    sequenceMode:       true,
+                    tileSources:        "'.$tileSource.'"
 
-                $mainImage = true;
+                });
+                </script></div>';
+
+                                $mainImage = true;
+
+
+
+
 
             }
             // we need to display a thumbnail


### PR DESCRIPTION
This branch should probably be called LIB001-1700 IIIF Collections. 

Changes currently to theme/art/views/record.php and header.php to bring in OpenSeadragon viewing. Currently this is based on lac-luna-test2 LUNA IIIF records- obviously there will be changes when we have content in live LUNA.

The viewer does not need to be OpenSeadragon, could be Leaflet. The thumbnails on this page are static IIIF also, but I'm currently just guessing where they should be cropped due to a bug which will be resolved in the next release of LUNA. Resultantly, they look a bit odd.