### PR TITLE
fixed the bug that the entries are displayed as arrays on lhsacasenot…

### DIFF
--- a/config/mimed.php
+++ b/config/mimed.php
@@ -116,7 +116,13 @@ $config['skylight_search_fields'] = array(
     'Accession Number' => 'dc.identifier.en'
 );
 
-$config['skylight_related_fields'] = array('Instrument' => 'dc.type.en', 'Genus' => 'dc.type.genus.en');
+// BUGFIX: Identifier added as a hack to prevent records missing either dc.type.en or dc.type.genus.en from passing *all* their solr data to the getRelatedItems function and overloading the URL
+// We used identifier, because it shouldn't change the returned results at all, following this logic:
+// 1) The search terms are quoted, so a search on the quoted identifier should only ever return the same record
+// 2) The function adds a query parameter to remove matches with the same handle (to prevent the same record showing up in its own Related Items block)
+// 3) Therefore, the two operations will cancel each other out and not return an additional result
+// Sebastian + Mike - 10th Aug 2020
+$config['skylight_related_fields'] = array('Instrument' => 'dc.type.en', 'Genus' => 'dc.type.genus.en', 'Identifier' => 'dc.identifier.en');
 
 //only by title, no date at the moment
 $config['skylight_sort_fields'] = array(

--- a/theme/lhsacasenotes/views/record.php
+++ b/theme/lhsacasenotes/views/record.php
@@ -64,10 +64,17 @@ $bitstreamLinks = array();
                                         echo $metadatavalue;
                                         $idset = true;
                                     }
-                                }
-                                else{
-
-                                    echo $metadatavalue;
+                                } //13.08.2020 Sebastian Lange: Dates and Extent were falsly outputted as array this fairly horrible if else statement fixed it
+                                else {
+                                    if($key == 'Dates'){
+                                        echo ($metadatavalue['expression']);
+                                    }
+                                    if($key == 'Extent'){
+                                        echo ($metadatavalue['number']);
+                                    }
+                                    elseif ($key != 'Dates') {
+                                        echo ($metadatavalue);
+                                    }
                                 }
                             }
 

--- a/theme/towardsdolly/views/record.php
+++ b/theme/towardsdolly/views/record.php
@@ -47,21 +47,24 @@ $bitstreamLinks = array();
 
                                 echo '<a href="./search/*:*/' . $key . ':%22'.$orig_filter.'%22">'.$metadatavalue.'</a>';
                             }
-                            else
-                            {
-                                if ($key == 'Identifier')
-                                {
-                                    if ($idset == false)
-                                    {
+                            else {
+                                if ($key == 'Identifier') {
+                                    if ($idset == false) {
                                         echo $metadatavalue;
                                         $idset = true;
                                     }
+                                } //13.08.2020 Sebastian Lange: Dates and Extent were falsly outputted as array this fairly horrible if else statement fixed it
+                                else {
+                                    if($key == 'Dates'){
+                                        echo ($metadatavalue['expression']);
+                                    }
+                                    if($key == 'Extent'){
+                                        echo ($metadatavalue['number']);
+                                    }
+                                    elseif ($key != 'Dates') {
+                                        echo ($metadatavalue);
+                                    }
                                 }
-                                else
-                                {
-                                    echo $metadatavalue;
-                                }
-
                             }
 
                             if($index < sizeof($solr[$element]) - 1) {


### PR DESCRIPTION
…es and dolly + a hacky workaround to quickfix the mimed endlesslinks

Still there is action required for fairbain to solve the same problem but I haven't had a change to do so. 