### PR TITLE
LUC023A-215 point directly at ArchivesSpace

### DIFF
--- a/config/bodylanguage.php
+++ b/config/bodylanguage.php
@@ -11,7 +11,7 @@ if(ENVIRONMENT == 'development') {
     $config['skylight_link_url'] = 'http://lac-archives-live.is.ed.ac.uk:8081';
 
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
-        $config['skylight_solrbase'] = 'http://localhost:9129/';
+        $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
 
     } else {
         $config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
@@ -19,7 +19,7 @@ if(ENVIRONMENT == 'development') {
 }
 else {
     $config['skylight_ga_code'] = 'UA-25737241-9';
-    $config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
+    $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
     $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
 }
 

--- a/config/fairbairn.ac.uk.php
+++ b/config/fairbairn.ac.uk.php
@@ -9,12 +9,12 @@ $config['skylight_appname'] = 'fairbairn';
 if (ENVIRONMENT == 'development') {
     $config['base_url'] = 'http://test.fairbairn.ac.uk/';
     $config['skylight_ga_code'] = '';
-    $config['skylight_solrbase'] = 'http://lac-repo-test14.is.ed.ac.uk:8090/';
+    $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
 }
 else {
     $config['base_url'] = 'http://www.fairbairn.ac.uk/';
     $config['skylight_ga_code'] = 'UA-25737241-19';
-    $config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
+    $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
 }
 
 $config['skylight_repository_type'] = 'archivesspace'; // Demo 'dspace'

--- a/config/lhsacasenotes.php
+++ b/config/lhsacasenotes.php
@@ -9,11 +9,11 @@ $config['skylight_url_prefix'] = 'lhsacasenotes';
 if(ENVIRONMENT == 'development') {
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://localhost:9129/';
+        $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archives-test.is.ed.ac.uk:8081';
     } else if (strpos($_SERVER['HTTP_HOST'], "test") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-repo-test14.is.ed.ac.uk:8090/';
+        $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archives-live.is.ed.ac.uk:8081';
         //$config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
         //$config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
@@ -21,7 +21,7 @@ if(ENVIRONMENT == 'development') {
 }
 else {
     $config['skylight_ga_code'] = 'UA-25737241-9';
-    $config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
+    $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
     $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
 }
 

--- a/config/towardsdolly.php
+++ b/config/towardsdolly.php
@@ -10,17 +10,17 @@ $config['skylight_url_prefix'] = 'towardsdolly';
 if(ENVIRONMENT == 'development') {
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://localhost:9129/';
+        $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archives-test.is.ed.ac.uk:8081';
     } else if (strpos($_SERVER['HTTP_HOST'], "test") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-repo-test14.is.ed.ac.uk:8090/';
+        $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archives-test.is.ed.ac.uk:8081';
     }
 }
 else {
     $config['skylight_ga_code'] = 'UA-25737241-9';
-    $config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
+    $config['skylight_solrbase'] = 'http://lac-archives-live.is.ed.ac.uk:8090/';
     $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
 }
 


### PR DESCRIPTION
Changes to use ArchivesSpace as solrbase so we can commission the repo-*-14 machines.
bodylanguage, towardsdolly, fairbairn and lhsacasenotes affected.
