### PR TITLE
Reverting to live1:8090 collection1

### DIFF
--- a/config/bodylanguage.php
+++ b/config/bodylanguage.php
@@ -1,7 +1,8 @@
 <?php
 
 $config['skylight_appname'] = 'bodylanguage';
-$config['skylight_solr_core'] = 'solr/archivesspace';
+//$config['skylight_solr_core'] = 'solr/archivesspace';
+$config['skylight_solr_core'] = 'collection1';
 
 // Uncomment this if you are using a url of the form http://.../art/...
 $config['skylight_url_prefix'] = 'bodylanguage';
@@ -9,18 +10,18 @@ $config['skylight_url_prefix'] = 'bodylanguage';
 // Global CodeIgniter ENVIRONMENT variable is set in skylight/index.php
 if(ENVIRONMENT == 'development') {
     $config['skylight_ga_code'] = '';
-    $config['skylight_link_url'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8081';
+    $config['skylight_link_url'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8081';
 
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
 
     } else {
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
     }
 }
 else {
     $config['skylight_ga_code'] = 'G-L20JS09H7H';
-    $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+    $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
     $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
 }
 

--- a/config/eerc.php
+++ b/config/eerc.php
@@ -1,6 +1,7 @@
 <?php
 $config['skylight_appname'] = 'eerc';
-$config['skylight_solr_core'] = 'solr/archivesspace';
+//$config['skylight_solr_core'] = 'solr/archivesspace';
+$config['skylight_solr_core'] = 'collection1';
 
 // Uncomment this if you are using a url of the form http://.../art/...
 $config['skylight_url_prefix'] = 'eerc';
@@ -9,11 +10,11 @@ $config['skylight_url_prefix'] = 'eerc';
 if(ENVIRONMENT == 'development') {
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
         $config['skylight_ga_code'] = 'G-RYHXTMGMHR';
-        $config['skylight_solrbase'] = 'http://localhost:9123/';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8081';
     } else if (strpos($_SERVER['HTTP_HOST'], "test") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8081';
         //$config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:9123/';
         //$config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
@@ -21,7 +22,7 @@ if(ENVIRONMENT == 'development') {
 }
 else {
     $config['skylight_ga_code'] = 'G-L20JS09H7H';
-    $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+    $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
     $config['skylight_link_url'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8081';
     //$config['skylight_solrbase'] = 'http://lac-repo-live11.is.ed.ac.uk:8090/';
     //    $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';

--- a/config/fairbairn.ac.uk.php
+++ b/config/fairbairn.ac.uk.php
@@ -1,7 +1,8 @@
 <?php
 
 $config['skylight_appname'] = 'fairbairn';
-$config['skylight_solr_core'] = 'solr/archivesspace';
+//$config['skylight_solr_core'] = 'solr/archivesspace';
+$config['skylight_solr_core'] = 'collection1';
 
 // Uncomment this if you are using a url of the form http://.../art/...
 //$config['skylight_url_prefix'] = 'fairbairn';
@@ -10,12 +11,12 @@ $config['skylight_solr_core'] = 'solr/archivesspace';
 if (ENVIRONMENT == 'development') {
     $config['base_url'] = 'http://test.fairbairn.ac.uk/';
     $config['skylight_ga_code'] = 'G-X4CRLZFCQM';
-    $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+    $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
 }
 else {
     $config['base_url'] = 'http://www.fairbairn.ac.uk/';
     $config['skylight_ga_code'] = 'G-1HP342X330';
-    $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+    $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
 }
 
 $config['skylight_repository_type'] = 'archivesspace'; // Demo 'dspace'

--- a/config/lhsacasenotes.php
+++ b/config/lhsacasenotes.php
@@ -1,7 +1,8 @@
 <?php
 
 $config['skylight_appname'] = 'lhsacasenotes';
-$config['skylight_solr_core'] = 'solr/archivesspace';
+//$config['skylight_solr_core'] = 'solr/archivesspace';
+$config['skylight_solr_core'] = 'collection1';
 
 // Uncomment this if you are using a url of the form http://.../art/...
 $config['skylight_url_prefix'] = 'lhsacasenotes';
@@ -10,20 +11,20 @@ $config['skylight_url_prefix'] = 'lhsacasenotes';
 if(ENVIRONMENT == 'development') {
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
-        $config['skylight_link_url'] = 'http://lac-archivesspace-test4.is.ed.ac.uk:8081';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
+        $config['skylight_link_url'] = 'http//lac-archivesspace-live1.is.ed.ac.uk:8081';
     } else if (strpos($_SERVER['HTTP_HOST'], "test") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
-        $config['skylight_link_url'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8081';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
+        $config['skylight_link_url'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8081';
         //$config['skylight_solrbase'] = 'http://lac-repo-live14.is.ed.ac.uk:8090/';
         //$config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
     }
 }
 else {
     $config['skylight_ga_code'] = 'G-L20JS09H7H';
-    $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
-    $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
+    $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
+    $config['skylight_link_url'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8081';
 }
 
 $config['skylight_repository_type'] = 'archivesspace'; // Demo 'dspace'

--- a/config/towardsdolly.php
+++ b/config/towardsdolly.php
@@ -1,7 +1,8 @@
 <?php
 
 $config['skylight_appname'] = 'towardsdolly';
-$config['skylight_solr_core'] = 'solr/archivesspace';
+//$config['skylight_solr_core'] = 'solr/archivesspace';
+$config['skylight_solr_core'] = 'collection1';
 
 // Uncomment this if you are using a url of the form http://.../art/...
 $config['skylight_url_prefix'] = 'towardsdolly';
@@ -11,17 +12,17 @@ $config['skylight_url_prefix'] = 'towardsdolly';
 if(ENVIRONMENT == 'development') {
     if (strpos($_SERVER['HTTP_HOST'], "localhost") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archivesspace-test4.is.ed.ac.uk:8081';
     } else if (strpos($_SERVER['HTTP_HOST'], "test") !== false) {
         $config['skylight_ga_code'] = '';
-        $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+        $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
         $config['skylight_link_url'] = 'http://lac-archivesspace-test4.is.ed.ac.uk:8081';
     }
 }
 else {
     $config['skylight_ga_code'] = 'G-L20JS09H7H';
-    $config['skylight_solrbase'] = 'http://lac-archivesspace-live4.is.ed.ac.uk:8983/';
+    $config['skylight_solrbase'] = 'http://lac-archivesspace-live1.is.ed.ac.uk:8090/';
     $config['skylight_link_url'] = 'http://archives.collections.ed.ac.uk';
 }
 


### PR DESCRIPTION
Reverting across 5 configs to collection1 and lac-archivesspace-live1.is.ed.ac.uk:8090.

Keeping config item for solrbase.

Checking link_prefix_uri in record.php.