### PR TITLE
LUC023A-233 Accessibility fixes for the main collections website.

### DIFF
--- a/static/clds/collections-as-data.php
+++ b/static/clds/collections-as-data.php
@@ -1,11 +1,11 @@
 <div class="tab-list">
   <div class="container">
-    <img src="../theme/clds/images/cad.png" class="banimage"/>
+    <h1 class="bantext">Collections As Data</h1>
         <div>
         <h4 class="wrap">
           We are making full collections available as downloadable datasets. These can then be used as the basis of digital scholarship research, for text mining, data carpentry, and beyond. The content is available in zip format for download, and information around API calls to access them that way will be published here in due course.
         </h4>
-        <h4 class="wrap-bold">NB: please login to EASE before attempting your download. You can do this by opening <a href="https://collectionsmanager.is.ed.ac.uk" target="_blank">Collections Manager</a>.</h4>
+        <h4 class="wrap-bold">NB: please login to EASE before attempting your download. You can do this by opening <a href="https://collectionsmanager.is.ed.ac.uk" target="_blank" onclick="return warnNewTab()">Collections Manager</a>.</h4>
         <br/>
        <!-- <h3>The Digitised Theses</h3>
         <p>The Digitised Theses contains....
@@ -18,10 +18,10 @@
         <img src="../theme/clds/images/statacc.png" class="zipimage">
         <br/>
         <br/>
-        <h4 class="wrap">The Scottish Statistical Accounts zip contains all the pages from the OSA (Old Statistical Account) and the NSA (New Statistical Account) to be found at the website <a href="https://stataccscot.edina.ac.uk/static/statacc/dist/home" target="_blank" title="Scottish Statistical Accounts" />https://stataccscot.edina.ac.uk</a>.<h4>
+        <h4 class="wrap">The Scottish Statistical Accounts zip contains all the pages from the OSA (Old Statistical Account) and the NSA (New Statistical Account) to be found at the website <a href="https://stataccscot.edina.ac.uk/static/statacc/dist/home" target="_blank" onclick="return warnNewTab()" title="Scottish Statistical Accounts" />https://stataccscot.edina.ac.uk</a>.<h4>
           <br/>
         <h3>
-          <a href="https://collectionsmanager.is.ed.ac.uk/bitstream/handle/10683/119269/statacc_pages.zip?sequence=1&isAllowed=y" target="_blank">Direct Download</a> &nbsp;&bull;&nbsp;<a href="https://collectionsmanager.is.ed.ac.uk/handle/10683/119269" target="_blank">DSpace Record</a></h3>
+          <a href="https://collectionsmanager.is.ed.ac.uk/bitstream/handle/10683/119269/statacc_pages.zip?sequence=1&isAllowed=y" target="_blank" onclick="return warnNewTab()">Direct Download</a> &nbsp;&bull;&nbsp;<a href="https://collectionsmanager.is.ed.ac.uk/handle/10683/119269" target="_blank" onclick="return warnNewTab()">DSpace Record</a></h3>
           <br/>
        </div> 
 
@@ -31,10 +31,10 @@
         <img src="../theme/clds/images/theses.png" class="zipimage">
         <br/>
         <br/>
-        <h4 class="wrap">The Digitised PhD Theses zip contains all the theses in the <a href="https://era.ed.ac.uk" target="_blank" title="ERA">Edinburgh Research Archive</a>, dating back to the 17th century. 60% of these were created by the <a href="http://libraryblogs.is.ed.ac.uk/phddigitisation/" target="_blank" title="PhD Digitisation Project" />PhD digitisation project</a> of 2018. More information at the <a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/collections/theses" title="CRC theses pages" target="_blank">CRC webpages.</a><h4>
+        <h4 class="wrap">The Digitised PhD Theses zip contains all the theses in the <a href="https://era.ed.ac.uk" target="_blank" onclick="return warnNewTab()" title="ERA">Edinburgh Research Archive</a>, dating back to the 17th century. 60% of these were created by the <a href="http://libraryblogs.is.ed.ac.uk/phddigitisation/" target="_blank" onclick="return warnNewTab()" title="PhD Digitisation Project" />PhD digitisation project</a> of 2018. More information at the <a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/collections/theses" title="CRC theses pages" target="_blank" onclick="return warnNewTab()">CRC webpages.</a><h4>
           <br/>
         <h3>
-          <a href="https://collectionsmanager.is.ed.ac.uk/bitstream/handle/10683/119277/theses.zip?sequence=1&isAllowed=y" target="_blank" title="Download Digitised Theses zip">Direct Download</a> &nbsp;&bull;&nbsp;<a href="https://collectionsmanager.is.ed.ac.uk/handle/10683/119277" target="_blank" title="Digitised Theses DSpace Record">DSpace Record</a></h3>
+          <a href="https://collectionsmanager.is.ed.ac.uk/bitstream/handle/10683/119277/theses.zip?sequence=1&isAllowed=y" target="_blank" onclick="return warnNewTab()" title="Download Digitised Theses zip">Direct Download</a> &nbsp;&bull;&nbsp;<a href="https://collectionsmanager.is.ed.ac.uk/handle/10683/119277" target="_blank" onclick="return warnNewTab()" title="Digitised Theses DSpace Record">DSpace Record</a></h3>
           <br/>
       </div>
       <div>     

--- a/static/clds/csp.php
+++ b/static/clds/csp.php
@@ -47,7 +47,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/EUL0011.json" title="CSP/11"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -65,7 +65,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/EUL0281.json" title="CSP/281"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -87,7 +87,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/690_1811-196911821-28.json" title="690:1811-19 691:1821-28"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -105,7 +105,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/1801785-1800.json" title="180:1785-1800"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -123,7 +123,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/F_XXXIII_1741-42.json" title="F XXXIII: 1741-42"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -141,7 +141,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/Miscellaneous_Coll_x_Summer_Sess_813-814.json" title="Miscellaneous Coll x Summer Sess (813-814)"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -159,7 +159,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/General_Collection_of_Session_Papers_1831_12_FEB_-23_FEB_221_224-257.json" title="General Collection of Session Papers 1831 (12 FEB -23 FEB) 221; 224-753"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -177,7 +177,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/Chalmers_1765-1769" title="Chalmers 1765-1769"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -196,7 +196,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/Erskine_1_Vol._22.json" title="Erskine 1, Vol. 22"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -218,7 +218,7 @@
 
                         <div class="curl"></div>
                         <a href="https://librarylabs.ed.ac.uk/iiif/uv/?manifest=https://librarylabs.ed.ac.uk/iiif/manifest/sessionpapers/volumes/IA_-_466A.json" title="IA - 466A"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>

--- a/static/clds/directory.php
+++ b/static/clds/directory.php
@@ -17,7 +17,7 @@
         <p>
 
             You can purchase hardback and paperback copies of the Directory of the Collections, published by Third
-            Millennium, at the Centre for Research Collections and the University of Edinburgh Visitor Centre, as well as <a href="https://tmbooks.com/directory-of-collections-at-the-university-of-edinburgh.html" title="External link to Third Millenium Shop" target="_blank">online</a>.
+            Millennium, at the Centre for Research Collections and the University of Edinburgh Visitor Centre, as well as <a href="https://tmbooks.com/directory-of-collections-at-the-university-of-edinburgh.html" title="External link to Third Millenium Shop" target="_blank" onclick="return warnNewTab()">online</a>.
         </p>
 
         <p>Directory of Collections, Copyright &copy; The University of Edinburgh, 2016</p>

--- a/static/clds/mahabharata.php
+++ b/static/clds/mahabharata.php
@@ -38,9 +38,9 @@
 
 </p>
 <p>
-  The scroll has been made available to view online using <a href="https://iiif.io" title="International Image Interoperability Framework" target="_blank">IIIF</a>
+  The scroll has been made available to view online using <a href="https://iiif.io" title="International Image Interoperability Framework" target="_blank" onclick="return warnNewTab()">IIIF</a>
   image and presentation APIs, that stitch the images together in realtime to enable you to scroll up and down. There is more information about the digitisation in a
-  <a href="http://libraryblogs.is.ed.ac.uk/diu/2018/06/22/a-stitch-in-time-mahabharata-delivered-online/" title="Digitisation Blog post" target="_blank">blog post</a>.
+  <a href="http://libraryblogs.is.ed.ac.uk/diu/2018/06/22/a-stitch-in-time-mahabharata-delivered-online/" title="Digitisation Blog post" target="_blank" onclick="return warnNewTab()">blog post</a>.
         </div>
   </div>
 </div>

--- a/static/clds/participate.php
+++ b/static/clds/participate.php
@@ -14,7 +14,7 @@
         <h3>Volunteer with us</h3>
         <p>There are a range of ways to get involved with our collections, and we have a number of volunteer opportunities
             to suit all abilities and areas of interest.  If you would like to volunteer with us, please go to:
-            <a href="http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery/crc/volunteers-interns" target="_blank">volunteers and interns</a> for more information.
+            <a href="http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery/crc/volunteers-interns" target="_blank" onclick="return warnNewTab()">volunteers and interns</a> for more information.
         </p>
         <h3>Library Foundation Fund</h3>
       <p>The <a href="http://www.ed.ac.uk/schools-departments/information-services/about/organisation/library-and-collections/library-foundation-fund" title="Library Foundation Fund">Library Foundation Fund</a>

--- a/theme-local/clds/css/picgallery.css
+++ b/theme-local/clds/css/picgallery.css
@@ -45,7 +45,6 @@ figure.clickbox > div::before {
 figure.clickbox h2 {
     word-spacing: -0.1em;
     font-weight: 400;
-    text-transform: uppercase;
     top: 0;
     opacity: 1;
     padding: 15px;

--- a/theme-local/clds/css/secondmenu.css
+++ b/theme-local/clds/css/secondmenu.css
@@ -2,11 +2,10 @@
 .cldmenu {
 	padding: 0;
 	text-align: center;
-    font-size: 8px;
+    font-size: 12px;
     letter-spacing: 1.5px;
     line-height: 1em;
     margin: 5px 40px;
-    text-transform: uppercase;
 }
 .cldmenu li {
     display: inline-block;
@@ -56,19 +55,19 @@
 
 @media (min-width: 768px) {
     .cldmenu {
-        font-size: 12px;
+        font-size: 14pt;
     }
 }
 
 
 @media (min-width: 992px) {
 	.cldmenu {
-		font-size: 12px;
+		font-size: 14pt;
 	}
 }
 
 @media (min-width: 1200px) {
 	.cldmenu {
-		font-size: 16px;
+		font-size: 18pt;
 	}
 }

--- a/theme-local/clds/css/style.css
+++ b/theme-local/clds/css/style.css
@@ -2,6 +2,7 @@ body {
     font-family: Arial, Helvetica, sans-serif;
     background-color: #fff;
     color: #333;
+    font-size: 12pt;
 }
 
 #myCarousel {
@@ -58,7 +59,6 @@ body {
 }
 
 #navbar-smallword {
-    text-transform: uppercase;
     padding: 10px 0;
     font-weight: bold;
 }
@@ -171,14 +171,12 @@ body {
 
 .tab-col a {
     color: #004F71;
-    text-transform: uppercase;
     font-weight: bold;
     font-size: 42px;
     text-align: center;
 }
 
 .tab-col span, .tab-visit h2, .tab-participate h2 {
-    text-transform: uppercase;
     font-size: 42px;
     text-align: center;
     word-spacing: -0.1em;
@@ -194,7 +192,6 @@ body {
 
 
 .tab-visit h4{
-    text-transform: uppercase;
     font-size: 26px;
     text-align: center;
     word-spacing: -0.1em;
@@ -421,7 +418,7 @@ fieldset[disabled] .btn-custom.active {
 .footer {
     background-color: #252525;
     font-size: 16px;
-    color: #ccc;
+    color: #fff;
     font-family: "Source Sans Pro", sans-serif;
     padding-top :10px;
     margin:0 0 0 0}
@@ -437,8 +434,8 @@ fieldset[disabled] .btn-custom.active {
 }
 
 .footer a {
-    color: #ccc;
-    text-decoration: none;
+    color: #fff;
+    text-decoration: underline;
 }
 
 .footer a.hover {
@@ -455,7 +452,6 @@ fieldset[disabled] .btn-custom.active {
     font-size: 1.8em;
     font-weight: 400;
     color: #ffffff;
-    text-transform: uppercase;
 }
 
 .container-footer-copyright
@@ -611,7 +607,7 @@ fieldset[disabled] .btn-custom.active {
         background-color: #F3E3D4;
     }
     #navbar-middle li {
-        font-size: 12px;
+        font-size: 12pt;
     }
     #navbar-right {
         position: relative;
@@ -642,7 +638,7 @@ fieldset[disabled] .btn-custom.active {
         font-size: 20px;
     }
     .footer p {
-        font-size: 11px;
+        font-size: 12pt;
     }
     #footer .container {
         width: 600px;
@@ -669,7 +665,7 @@ fieldset[disabled] .btn-custom.active {
         padding-top: 190px;
     }
     #navbar-middle li {
-        font-size: 14px;
+        font-size: 14pt;
     }
     #navbar-right {
         position: relative;
@@ -697,7 +693,7 @@ fieldset[disabled] .btn-custom.active {
         font-size: 25px;
     }
     .footer p {
-        font-size: 13px;
+        font-size: 13pt;
     }
     #footer .container {
         width: 870px;
@@ -742,7 +738,7 @@ fieldset[disabled] .btn-custom.active {
     }
 
     #navbar-middle li {
-        font-size: 16px;
+        font-size: 18px;
     }
 
     #navbar-collapse ul li a {
@@ -842,9 +838,12 @@ fieldset[disabled] .btn-custom.active {
     
 }
 
-.banimage {
-    height:65% !important;
-    width:65% !important;
+.bantext {
+    font-family: inherit;
+    font-size: 50pt;
+    font-weight: bold;
+    color: #1A4367;
+    text-align: center;
 }
 
 .message {
@@ -858,10 +857,23 @@ fieldset[disabled] .btn-custom.active {
 
 .wrap{
     font-size:15pt;
-    text-align: justify;
 }
 .wrap-bold{
     font-size:15pt;
-    text-align: justify;
     font-weight:bold;
+}
+
+a {
+    text-decoration: underline;
+}
+
+.navbar-nav>li>a {
+    text-decoration: none;
+}
+.navbar-nav>li>a:hover {
+    text-decoration: underline;
+}
+
+a:focus {
+    outline-color: ;
 }

--- a/theme/clds/views/header.php
+++ b/theme/clds/views/header.php
@@ -90,11 +90,17 @@
 </head>
 <body>
 
+<script>
+    function warnNewTab() {
+      return confirm("This link will open in a new tab. Proceed?");
+    }
+  </script>
+
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container">
         <div class="navbar-header">
             <div id="collection-title">
-                <a href="https://www.ed.ac.uk" class="navbar-brand logo" title="The University of Edinburgh Home" target="_blank"><img src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/images/UoELogo.gif" alt="The University of Edinburgh Logo"/></a>
+                <a href="https://www.ed.ac.uk" class="navbar-brand logo" title="The University of Edinburgh Home" target="_blank" onclick="return warnNewTab()"><img src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/images/UoELogo.gif" alt="The University of Edinburgh Logo"/></a>
                 <div id="navbar-word">
                     <a href="<?php echo base_url(); ?>" class="collectionslogo" title="University of Edinburgh Collections Home"></a>
                 </div>
@@ -110,15 +116,15 @@
         </div>
         <div class="collapse navbar-collapse" id="navbar-collapse">
             <ul class="nav navbar-nav" id="navbar-middle">
-                <li><a href="#" title="University of Edinburgh Collections Home">HOME</a></li>
-                <li><a href="https://collections.ed.ac.uk/about" target="_blank" title="About Edinburgh University Collections">ABOUT</a></li>
-                <li><a href="https://collections.ed.ac.uk/feedback/" target="_blank" title="Provide feedback">FEEDBACK</a></li>
+                <li><a href="#" title="University of Edinburgh Collections Home">Home</a></li>
+                <li><a href="https://collections.ed.ac.uk/about" target="_blank" title="About Edinburgh University Collections" onclick="return warnNewTab()">About</a></li>
+                <li><a href="https://collections.ed.ac.uk/feedback/" target="_blank" title="Provide feedback" onclick="return warnNewTab()">Feedback</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right hidden-xs" id="navbar-right">
-                <li><a href="https://www.facebook.com/crc.edinburgh" target="_blank" title="CRC Facebook Page"><i id="social-fb" class="fa fa-facebook-square fa-3x social" aria-hidden="true"></i></a></li>
-                <li><a href="https://twitter.com/CRC_EdUni" target="_blank" title="CRC Twitter Feed"><i id="social-tw" class="fa fa-twitter-square fa-3x social" aria-hidden="true"></i></a></li>
-                <li><a href="https://www.flickr.com/photos/crcedinburgh" target="_blank" title="CRC Flickr Page"><i id="social-fr" class="fa fa-flickr fa-3x social" aria-hidden="true"></i></a></li>
-                <li><a href="http://libraryblogs.is.ed.ac.uk/" target="_blank" title="University of Edinburgh Library Blogs"><i id="social-wp" class="fa fa-wordpress fa-3x social" aria-hidden="true"></i></a></li>
+                <li><a href="https://www.facebook.com/crc.edinburgh" target="_blank" title="CRC Facebook Page" onclick="return warnNewTab()" data-toggle="tooltip" data-trigger="focus"><i id="social-fb" class="fa fa-facebook-square fa-3x social" aria-hidden="true"></i></a></li>
+                <li><a href="https://twitter.com/CRC_EdUni" target="_blank" title="CRC Twitter Feed" onclick="return warnNewTab()" data-toggle="tooltip" data-trigger="focus"><i id="social-tw" class="fa fa-twitter-square fa-3x social" aria-hidden="true"></i></a></li>
+                <li><a href="https://www.flickr.com/photos/crcedinburgh" target="_blank" title="CRC Flickr Page" onclick="return warnNewTab()" data-toggle="tooltip" data-trigger="focus"><i id="social-fr" class="fa fa-flickr fa-3x social" aria-hidden="true"></i></a></li>
+                <li><a href="http://libraryblogs.is.ed.ac.uk/" target="_blank" title="University of Edinburgh Library Blogs" onclick="return warnNewTab()" data-toggle="tooltip" data-trigger="focus"><i id="social-wp" class="fa fa-wordpress fa-3x social" aria-hidden="true"></i></a></li>
             </ul>
         </div>
     </div>
@@ -127,11 +133,11 @@
 <div class="tab-heading">
     <div class="container">
         <ul class="cldmenu" >
-            <li class="current" ><a href="https://collections.ed.ac.uk/search/*/Type:%22archives+%7C%7C%7C+Archives%22/Header:%22archives%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="ARCHIVES" title="Archive and Manuscript Collections">ARCHIVES</a></li>
-            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22rare+books+%7C%7C%7C+Rare+Books%22/Header:%22rarebooks%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="RARE BOOKS" title="Rare Book Collections">RARE BOOKS</a></li>
-            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22mimed+%7C%7C%7C+MIMEd%22/Header:%22mimed%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="MUSICAL INSTRUMENTS" title="Musical Instrument Collections">MUSICAL INSTRUMENTS</a></li>
-            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22art+%7C%7C%7C+Art%22/Header:%22art%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="ART" title="Art Collections">ART</a></li>
-            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22museums+%7C%7C%7C+Museums%22/Header:%22museums%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="MUSEUMS" title="Museums">MUSEUMS</a></li>
+            <li class="current" ><a href="https://collections.ed.ac.uk/search/*/Type:%22archives+%7C%7C%7C+Archives%22/Header:%22archives%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="ARCHIVES" title="Archive and Manuscript Collections">Archives</a></li>
+            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22rare+books+%7C%7C%7C+Rare+Books%22/Header:%22rarebooks%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="RARE BOOKS" title="Rare Book Collections">Rare Books</a></li>
+            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22mimed+%7C%7C%7C+MIMEd%22/Header:%22mimed%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="MUSICAL INSTRUMENTS" title="Musical Instrument Collections">Musical Instruments</a></li>
+            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22art+%7C%7C%7C+Art%22/Header:%22art%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="ART" title="Art Collections">Art</a></li>
+            <li><a href="https://collections.ed.ac.uk/search/*/Type:%22museums+%7C%7C%7C+Museums%22/Header:%22museums%22?sort_by=cld.weighting_sort+desc,dc.title_sort+asc" data-hover="MUSEUMS" title="Museums">Museums</a></li>
         </ul>
     </div>
 </div>

--- a/theme/clds/views/index.php
+++ b/theme/clds/views/index.php
@@ -1,7 +1,7 @@
 <div class="tab-list">
     <div class="container">
         <div class="row">
-            <p class="tab-h2">Online Collections</p>
+            <h1 class="tab-h2">Online Collections</h1>
         </div>
         <div class="row">
             <div class="col-sm-6 col-xs-12">
@@ -15,7 +15,7 @@
                         <i class="fa fa-external-link"></i>
                         <i class="ion-arrow-right-c"></i>
                         <div class="curl"></div>
-                        <a href="https://archives.collections.ed.ac.uk/" title="Archives" target="_blank"></a>
+                        <a href="https://archives.collections.ed.ac.uk/" title="Archives" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -29,7 +29,7 @@
                         <i class="fa fa-camera"></i>
                         <i class="ion-arrow-right-c"></i>
                         <div class="curl"></div>
-                        <a href="https://collections.ed.ac.uk/art" title="Art Collection" target="_blank"></a>
+                        <a href="https://collections.ed.ac.uk/art" title="Art Collection" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -46,7 +46,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="https://collections.ed.ac.uk/mimed" title="Musical Instruments" target="_blank"></a>
+                        <a href="https://collections.ed.ac.uk/mimed" title="Musical Instruments" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -65,7 +65,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="https://collections.ed.ac.uk/iconics" title="Iconics Collection" target="_blank"></a>
+                        <a href="https://collections.ed.ac.uk/iconics" title="Iconics Collection" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -118,7 +118,7 @@
 <div class="tab-list2">
     <div class="container">
         <div class="row">
-            <p class="tab-h2">Digital Image Collections</p>
+            <h1 class="tab-h2">Digital Image Collections</h1>
         </div>
         <div class="row">
             <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
@@ -134,7 +134,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEcha~4~4" title="Anatomy Collection"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -152,7 +152,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEcar~3~3" title="Architectural Drawings"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -170,7 +170,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEcar~1~1" title="Carmichael Watson"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -188,7 +188,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEsha~1~1" title="Shakespeare"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -206,7 +206,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEwmm~3~3" title="ECA Rare Books"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -224,7 +224,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEecp~1~1" title="ECA Photography Collection"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -242,7 +242,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEsha~5~5" title="Geology and Geologists"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -260,7 +260,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEcar~4~4" title="Hill and Adamson"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -278,7 +278,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEgal~2~2" title="Incunabula"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -296,7 +296,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEwmm~2~2" title="Laing Collection"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -314,7 +314,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEcha~1~1" title="Maps Collection"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -332,7 +332,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEhal~2~2" title="Museums Collection"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -350,7 +350,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEsha~3~3" title="New College"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -368,7 +368,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEsha~4~4" title="Oriental Manuscripts"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -386,7 +386,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEgal~6~6" title="Roslin Institute"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -404,7 +404,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEcar~2~2" title="Salvesen"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -424,7 +424,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEgal~4~4"
-                           title="University of Edinburgh - People, Places &amp; Events" target="_blank"></a>
+                           title="University of Edinburgh - People, Places &amp; Events" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -442,7 +442,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images-teaching.is.ed.ac.uk/luna/servlet"
-                           title="Edinburgh University Image Teaching Collections Home" target="_blank"></a>
+                           title="Edinburgh University Image Teaching Collections Home" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -460,7 +460,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEwal~1~1" title="Walter Scott Collection"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -477,7 +477,7 @@
 
                         <div class="curl"></div>
                         <a href="https://images.is.ed.ac.uk/luna/servlet/UoEwmm~1~1"
-                           title="Western Medieval Manuscripts" target="_blank"></a>
+                           title="Western Medieval Manuscripts" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -488,7 +488,7 @@
 <div class="tab-list3">
     <div class="container">
         <div class="row">
-            <p class="tab-h2">Digitisation Projects</p>
+            <h1 class="tab-h2">Digitisation Projects</h1>
         </div>
         <div class="row">
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
@@ -529,7 +529,7 @@
 <div class="tab-list4">
     <div class="container">
         <div class="row">
-            <p class="tab-h2">Additional Collection Resources</p>
+            <h1 class="tab-h2">Additional Collection Resources</h1>
         </div>
         <div class="row">
             <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
@@ -545,7 +545,7 @@
 
                         <div class="curl"></div>
                         <a href="http://www.carmichaelwatson.lib.ed.ac.uk/cwatson/" title="Carmichael Watson Project"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -561,7 +561,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="http://www.fairbairn.ac.uk/" title="Fairbairn" target="_blank"></a>
+                        <a href="http://www.fairbairn.ac.uk/" title="Fairbairn" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -578,7 +578,7 @@
 
                         <div class="curl"></div>
                         <a href="https://collections.ed.ac.uk/lhsacasenotes" title="LHSA Case Notes"
-                           target="_blank"></a>
+                           target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -594,7 +594,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="https://collections.ed.ac.uk/towardsdolly" title="Towards Dolly" target="_blank"></a>
+                        <a href="https://collections.ed.ac.uk/towardsdolly" title="Towards Dolly" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -609,7 +609,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="https://collections.ed.ac.uk/alumni" title="Alumni" target="_blank"></a>
+                        <a href="https://collections.ed.ac.uk/alumni" title="Alumni" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -626,7 +626,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="https://collections.ed.ac.uk/guardbook" title="Guardbook" target="_blank"></a>
+                        <a href="https://collections.ed.ac.uk/guardbook" title="Guardbook" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -643,7 +643,7 @@
                         <i class="ion-arrow-right-c"></i>
 
                         <div class="curl"></div>
-                        <a href="http://www.tobarandualchais.co.uk/" title="Tobar an Dualchais" target="_blank"></a>
+                        <a href="http://www.tobarandualchais.co.uk/" title="Tobar an Dualchais" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -662,7 +662,7 @@
 
                         <div class="curl"></div>
                         <a href="https://www.era.lib.ed.ac.uk/browse?value=PhD+Doctor+of+Philosophy&type=type"
-                           title="Theses Collection in Edinburgh Research Archive" target="_blank"></a>
+                           title="Theses Collection in Edinburgh Research Archive" target="_blank" onclick="return warnNewTab()"></a>
                     </div>
                 </figure>
             </div>
@@ -865,7 +865,7 @@
                             <i class="ion-arrow-right-c"></i>
 
                             <div class="curl"></div>
-                            <a href="http://libraryblogs.is.ed.ac.uk/" title="Library BLogs" target="_blank"></a>
+                            <a href="http://libraryblogs.is.ed.ac.uk/" title="Library BLogs" target="_blank" onclick="return warnNewTab()"></a>
                         </div>
                     </figure>
                 </div>
@@ -882,7 +882,7 @@
 
                             <div class="curl"></div>
                             <a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/transfers-donations"
-                               title="Donate" target="_blank"></a>
+                               title="Donate" target="_blank" onclick="return warnNewTab()"></a>
                         </div>
                     </figure>
                 </div>
@@ -914,7 +914,7 @@
                             <i class="ion-arrow-right-c"></i>
 
                             <div class="curl"></div>
-                            <a href="https://www.ed.ac.uk/information-services/library-museum-gallery/cultural-heritage-collections/crc/volunteers-interns-fellowships/volunteers-interns" title="Volunteering" target="_blank"></a>
+                            <a href="https://www.ed.ac.uk/information-services/library-museum-gallery/cultural-heritage-collections/crc/volunteers-interns-fellowships/volunteers-interns" title="Volunteering" target="_blank" onclick="return warnNewTab()"></a>
                         </div>
                     </figure>
                 </div>
@@ -930,7 +930,7 @@
                             <i class="ion-arrow-right-c"></i>
 
                             <div class="curl"></div>
-                            <a href="https://librarylabs.ed.ac.uk/" title="Metadata Games" target="_blank"></a>
+                            <a href="https://librarylabs.ed.ac.uk/" title="Metadata Games" target="_blank" onclick="return warnNewTab()"></a>
                         </div>
                     </figure>
                 </div>


### PR DESCRIPTION
- Improve colour contrast. -> Footer links colour changed from #ccc -> #fff
- Underline links -> all links underlined by default, except for nav bar
- Increase font size where small text is present  -> increased the font size to 12pt website wide
- Remove the use of continuous capitals -> All instances of continuous capitals changed to sentence case
- Address the instances of text as an image, such as on the Collections as Data page. -> Collections as data changed from an image to an actual heading
- Alert the user to links that open in new tabs. -> (As a test) added JavaScript that lets the user know that a link will open a new tab once they have clicked on it and asks them to either proceed or cancel.
- Some headers on the main page were labelled as paragraphs -> now changed to h1
