### PR TITLE
LUC023A-233 Coimbra website accessibility fixes.

### DIFF
--- a/static/coimbra/about.php
+++ b/static/coimbra/about.php
@@ -1,4 +1,4 @@
-<div class="content">
+<div class="content" id="content">
     <div class="about-container">
 
         <div class="information-container col-xs-12 col-md-8 col-md-offset-2">
@@ -39,7 +39,7 @@
                 It is also the purpose of the Group to influence European educational policy and to develop best
                 practice through mutual exchange of experience.
                 <br/><br/>
-                <b><a href="https://www.coimbra-group.eu/" target="_blank">More information on the Coimbra Group Website</a></b>
+                <b><a href="" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="https://www.coimbra-group.eu/">More information on the Coimbra Group Website</a></b>
             </div>
         </div>
     </div>

--- a/static/coimbra/accessibility.php
+++ b/static/coimbra/accessibility.php
@@ -1,7 +1,7 @@
 <html>
 <div class="col-md-9 col-sm-9 col-xs-12">
     <div class="content byEditor">
-        <h1>Accessibility Statement for the <a href="https://collections.ed.ac.uk/coimbra">Coimbra Exhibition website</a></h1>
+        <h1 id="content">Accessibility Statement for the <a href="https://collections.ed.ac.uk/coimbra">Coimbra Exhibition website</a></h1>
         <p><strong>Website accessibility statement inline with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</strong></p>
         <p>This accessibility statement applies to  <a href="https://collections.ed.ac.uk/coimbra">https://collections.ed.ac.uk/coimbra</a></p>
 

--- a/static/coimbra/intro.php
+++ b/static/coimbra/intro.php
@@ -1,4 +1,4 @@
-<div class="col-xs-12 col-md-10 col-md-offset-1 col-lg-6 col-lg-offset-3 intro">
+<div  id="content" class="col-xs-12 col-md-10 col-md-offset-1 col-lg-6 col-lg-offset-3 intro">
     <img src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/images/lady.jpg" class="lady" alt="">
 
     <div class="intro-text">

--- a/static/coimbra/licensing.php
+++ b/static/coimbra/licensing.php
@@ -1,4 +1,4 @@
-<div class="content">
+<div class="content" id="content">
     <div class="container">
         <h2>Licensing and Copyright Information</h2>
         <p>

--- a/static/coimbra/takedown.php
+++ b/static/coimbra/takedown.php
@@ -1,4 +1,4 @@
-<div class="content">
+<div class="content" id="content">
     <div class="container">
         <h2>Takedown Policy</h2>
 

--- a/theme-local/coimbra/css/style.css
+++ b/theme-local/coimbra/css/style.css
@@ -48,12 +48,17 @@ body {
   position: relative;
   padding: 50px 0px 200px 0px;
   min-height: 100vh;
+  font-size: 12pt;
 }
 .row {
   margin: 0px;
 }
 .col-xs-12 {
   padding: 0px;
+}
+a {
+  text-decoration: underline;
+  cursor: pointer;
 }
 /* ---------------------
 
@@ -147,7 +152,7 @@ body {
   border-radius: 5px 0px 0px 5px;
   padding: 2px 7px 0px 10px;
   background-color: white;
-  font-size: 15px;
+  font-size: 18px;
 }
 #myNavbar .search::after {
   content: "";
@@ -167,8 +172,8 @@ body {
   border-radius: 0px 5px 5px 0px;
   background-color: transparent;
   color:white;
-  font-size: 15px;
-  height: 25px;
+  font-size: 18px;
+  height: 30px;
 }
 #myNavbar a {  /* underline links from center */
   position: relative;
@@ -293,7 +298,7 @@ body {
   padding: 10px 10px 0px 0px;
 }
 .footer a {
-  color: rgb(122, 232, 60);
+  color: #CCF5B2;
 }
 .footer p {
   clear: both;
@@ -310,7 +315,7 @@ body {
   list-style: none;
 }
 .footer a {
-  color: rgb(122, 232, 60);
+  color: #CCF5B2;
 }
 .footer img {
   line-height: 100%;
@@ -371,7 +376,22 @@ body {
 }
 .main-categories a {
   color: white;
+  border: 0.5px solid rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+  box-shadow: inset 0 0 10px 1px rgb(0, 120, 0);
+  backdrop-filter: blur(5px);
+  text-decoration: none;
 }
+
+@media screen and (min-width: 1355px) {
+  .main-categories a {
+    width: 14.2857%;
+    height: 25vh;
+    border-right: 1px solid rgba(240, 240, 240, 0.3);
+    border-bottom: 5px solid white;
+  }
+}
+
 @media screen and (min-width: 768px) {
   .main-categories {
     margin-top: calc(75vh - 50px);
@@ -380,17 +400,22 @@ body {
 
   }
   .main-categories a {
-    width: 13.5%;
+    text-align: center;
+    padding: 0;
+    /* width: 13.5%;
     height: 25vh;
     border-right: 1px solid rgba(240, 240, 240, 0.3);
-    border-bottom: 5px solid white;
+    border-bottom: 5px solid white; */
     color: white;
     background: rgba(0, 120, 0, 0.8);
-    font-size: 14px;
+    font-size: 16px;
     word-wrap: break-word;
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+/*  text-align: center;
     line-height: 25vh;
-    font-weight: bold;
+    font-weight: bold; */
     list-style: none;
     -webkit-transition: all 1s ease-in-out;
     -moz-transition: all 1s ease-in-out;
@@ -399,13 +424,18 @@ body {
     transition: all 1s ease-in-out;
   }
   .main-categories a.active {
-    border-bottom: none;
-    width: 19%;
+    /* border-bottom: none;
+    width: 19%; */
     background-color: rgb(0, 120, 0);
-    font-size: 22px;
+    /* font-size: 22px; */
   }
+
+  .border-b {
+    border-bottom: 5px solid white !important;
+  }
+
 }
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1355px) {
   .main-categories {
     margin-top: calc(100vh - 250px);
     width: 100vw;
@@ -414,8 +444,8 @@ body {
   .main-categories a {
     height: 50px;
     color: white;
-    background: rgba(0, 120, 0, 0.4);
-    font-size: 12px;
+    background: rgba(0, 120, 0, 0.8);
+    font-size: 16px;
     word-wrap: break-word;
     text-align: center;
     line-height: 50px;
@@ -501,7 +531,7 @@ nav #overflow li a:hover {
   }
 }
 
-@media only screen and (min-width: 1200px) {
+@media only screen and (min-width: 1310px) {
   #gallery-container {
     -moz-column-count: 4;
     -webkit-column-count: 4;
@@ -619,7 +649,7 @@ nav #overflow li a:hover {
     background-color: transparent;
     text-transform: uppercase;
     text-align: center;
-    font-size: 15px;
+    font-size: 18px;
     -webkit-transition-delay: 0.6s;
     transition-delay: 0.6s;
   }
@@ -760,7 +790,7 @@ nav #overflow li a:hover {
     padding: 10px 10px 10px 85px;
     color: white;
     text-align: center;
-    font-size: 20px;
+    font-size: 22px;
     -webkit-box-shadow: 0px 4px 10px -3px rgba(0,0,0,0.9);
     -moz-box-shadow: 0px 4px 10px -3px rgba(0,0,0,0.9);
     box-shadow: 0px 4px 10px -3px rgba(0,0,0,0.9);
@@ -773,7 +803,7 @@ nav #overflow li a:hover {
     height: 50px;
     border: 0px;
     color: white;
-    font-size: 25px;
+    font-size: 27px;
     z-index: 200;
   }
   .record-info .itemtitle .backbtn .fa-arrow-left{
@@ -826,7 +856,7 @@ nav #overflow li a:hover {
     width: 100%;
     display: block;
     color: rgb(230, 230, 230);
-    font-size: 0.9em;
+    font-size: 16px;
     font-weight: bold;
   }
   .invisible {
@@ -844,7 +874,7 @@ nav #overflow li a:hover {
     position: absolute;
     bottom: 10px;
     left: 50%;
-    font-size: 40px;
+    font-size: 42px;
     text-align: center;
     animation: move-arrow 2s ease-in-out 0s infinite, remove-arrow 2s linear 10s 1 forwards;
     -webkit-transition: all 4s ease;
@@ -924,7 +954,7 @@ nav #overflow li a:hover {
     padding: 10px 10px 10px 35px;
     color: rgb(0, 120, 0);
     text-align: center;
-    font-size: 16px;
+    font-size: 19px;
     font-weight: bold;
   }
   .record-info .itemtitle .backbtn {
@@ -936,7 +966,7 @@ nav #overflow li a:hover {
     width: 50px;
     border: 0px;
     color: rgb(0, 120, 0);
-    font-size: 18px;
+    font-size: 20px;
   }
   .record-info .itemtitle i {
     position: absolute;
@@ -969,61 +999,11 @@ nav #overflow li a:hover {
     width: 100%;
     display: block;
     color: rgb(0, 120, 0);
-    font-size: 0.9em;
+    font-size: 16px;
     font-weight: bold;
   }
 }
-/* ---------------------
 
-        LOADER
-
-------------------------*/
-#loader {
-  position: fixed;
-  z-index: 1000;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height:100vh;
-  line-height: 100vh;
-  text-align: center;
-  /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#1e5799+0,2989d8+50,207cca+51,7db9e8+100;Blue+Gloss+Default */
-  background: rgba(61, 140, 15, 0.8); /* Old browsers */
-  background: -moz-linear-gradient(top,  rgba(61, 140, 15, 0.8) 0%, rgba(99, 163, 62, 0.8) 50%, rgba(138, 186, 111, 0.8) 51%, rgba(177, 209, 159, 0.8) 100%); /* FF3.6-15 */
-  background: -webkit-linear-gradient(top,  rgba(61, 140, 15, 0.8) 0%,rgba(99, 163, 62, 0.8) 50%,rgba(138, 186, 111, 0.8) 51%,rgba(177, 209, 159, 0.8) 100%); /* Chrome10-25,Safari5.1-6 */
-  background: linear-gradient(to bottom,  rgba(61, 140, 15, 0.8) 0%,rgba(99, 163, 62, 0.8) 50%,rgba(138, 186, 111, 0.8) 51%,rgba(177, 209, 159, 0.8) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#3d8c0f', endColorstr='#b1d19f',GradientType=0 ); /* IE6-9 */
-}
-#loader .logo {
-  display: block;
-  width: 231px;
-  height: 177px;
-  margin: auto;
-  margin-top: calc(45vh - 100px);
-  animation-name: rotate-logo;
-  animation-duration: 6s;
-  animation-iteration-count: 3;
-}
-#loader h1 {
-  text-transform: uppercase;
-  display: block;
-  margin: 0px auto;
-  color: white;
-}
-@-webkit-keyframes rotate-logo {
-  0%   {-webkit-filter: brightness(100%); -webkit-filter: saturate(100%); -webkit-transform: rotate(0deg);}
-  25%  {-webkit-filter: brightness(150%); -webkit-filter: saturate(200%); -webkit-transform: rotate(20deg);}
-  50%  {-webkit-filter: brightness(200%); -webkit-filter: saturate(300%); -webkit-transform: rotate(-20deg);}
-  75%  {-webkit-filter: brightness(250%); -webkit-filter: saturate(400%); -webkit-transform: rotate(20deg);}
-  100% {-webkit-filter: brightness(300%); -webkit-filter: saturate(500%); -webkit-transform: rotate(0deg);}
-}
-@keyframes rotate-logo {
-  0%   {filter: brightness(100%); filter: saturate(100%); transform: rotate(0deg);}
-  25%  {filter: brightness(150%); filter: saturate(200%); transform: rotate(20deg);}
-  50%  {filter: brightness(200%); filter: saturate(300%); transform: rotate(-20deg);}
-  75%  {filter: brightness(250%); filter: saturate(400%); transform: rotate(20deg);}
-  100% {filter: brightness(300%); filter: saturate(500%); transform: rotate(0deg);}
-}
 /* ---------------------
 
         FEEDBACK
@@ -1041,7 +1021,7 @@ nav #overflow li a:hover {
   padding: 0px 10px 0px 10px;
 }
 .feedback_form input, .feedback_form textarea {
-  font-size: 20px;
+  font-size: 22px;
   width: 100%;
   border: 1px solid grey;
   border-radius: 5px;
@@ -1065,7 +1045,6 @@ nav #overflow li a:hover {
   padding: 15px;
 }
 .information-container .content {
-  text-align: justify;
   padding: 15px;
   background-color: rgb(230,230,230);
 }
@@ -1102,4 +1081,65 @@ nav #overflow li a:hover {
 .intro img {
   width: 100%;
   margin-top: 15px;
+}
+
+/* ---------------------
+    Skip to Content
+------------------------*/
+.screen-reader-text {
+  position: absolute !important;
+  clip-path: circle(0%);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  width: 1px;
+  word-wrap: normal!important;
+}
+
+.screen-reader-text:hover, .screen-reader-text:active, .screen-reader-text:focus {
+  z-index: 100000;
+  top: 5px;
+  left: 5px;
+  display: block;
+  width: auto;
+  height: auto;
+  text-decoration: none;
+  color: white;
+  border-radius: 3px;
+  background-color: rgb(19, 88, 19);
+  font-size: 12pt;
+  font-weight: bold;
+  line-height: normal;
+  clip-path: circle(100%);
+  padding: 8px;
+}
+
+/* ---------------------
+
+          Modal
+
+------------------------*/
+
+.modal-header{
+  color: white;
+  background-color: rgb(0, 120, 0);
+}
+
+.close {
+  color: #fff;
+  opacity: 1;
+}
+
+.btn-primary {
+  background-color: rgb(0, 120, 0);
+}
+
+.btn {
+  font-size: 16px;
+}
+
+.modal-body {
+  font-size: 17px;
 }

--- a/theme/coimbra/views/description.php
+++ b/theme/coimbra/views/description.php
@@ -17,7 +17,7 @@
                     echo '<a href="./search/*:*/' . $key . ':%22' . $lower_orig_filter . '+%7C%7C%7C+' . $orig_filter . '%22" title="' . $metadatavalue . '">' . $metadatavalue . '</a>';
                 }
                 else if (stripos($element, "uri") !== FALSE) {
-                      echo '<a href="' . $solr[$element][0] . '" title="URL Links for item" target="_blank">' . $solr[$element][0] . '</a>';
+                      echo '<a href="" title="URL Links for item" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="' . $solr[$element][0] . '">' . $solr[$element][0] . '</a>';
 
                 }
                 else {

--- a/theme/coimbra/views/div_main.php
+++ b/theme/coimbra/views/div_main.php
@@ -1,4 +1,4 @@
-<div class="container content col-xs-12">
+<div id="content" class="container content col-xs-12">
     <?php
     if(isset($page_heading)) {
         $page_title = $page_heading;

--- a/theme/coimbra/views/feedback.php
+++ b/theme/coimbra/views/feedback.php
@@ -26,7 +26,7 @@
         <p>
             If you have any questions, please contact: <a href="mailto:info@coimbra-group.eu">info@coimbra-group.eu</a>
         </p>
-        <p><a href="https://www.ed.ac.uk/records-management/notice" target="_blank">University of Edinburgh privacy statement</a></p>
+        <p><a href="" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="https://www.ed.ac.uk/records-management/notice">University of Edinburgh privacy statement</a></p>
     </div>
 
 </div>

--- a/theme/coimbra/views/footer.php
+++ b/theme/coimbra/views/footer.php
@@ -2,7 +2,7 @@
 </div><!--END of container - move into col sidebar -->
         <div class="footer">
             <div class="hidden-xs col-md-2 text-center">
-                <a href="https://www.ed.ac.uk" title="Link to University of Edinburgh Home Page" target="_blank"> <img style="height: 100px; width: 100px; position: relative; margin: 25px auto" src="<?php echo base_url()?>/theme/<?php echo $this->config->item('skylight_theme'); ?>/images/eduni-logo.png" alt="University of Edinburgh Logo"></a>
+                <a href="" title="Link to University of Edinburgh Home Page" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="https://www.ed.ac.uk"> <img style="height: 100px; width: 100px; position: relative; margin: 25px auto" src="<?php echo base_url()?>/theme/<?php echo $this->config->item('skylight_theme'); ?>/images/eduni-logo.png" alt="University of Edinburgh Logo"></a>
             </div>
             <div class="col-xs-12 col-md-10">
                 <ul>
@@ -10,7 +10,7 @@
 
                     <li><a href="https://www.ed.ac.uk/about/website/privacy">Privacy &amp; cookies</a></li>
 
-                    <li><a href="./accessibility" title="Website Accessibility Link" target="_blank">Accessibility</a></li>
+                    <li><a href="" title="Website Accessibility Link" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="./accessibility">Accessibility</a></li>
 
                     <li><a href="https://www.ed.ac.uk/about/website/freedom-information">Freedom of Information Publication Scheme</a></li>
 
@@ -21,6 +21,38 @@
             </div>
 
         </div>
+
+<!-- Modal -->
+<div class="modal fade" id="newTabNotice" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                        aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="myModalLabel">Notice</h4>
+            </div>
+            <div class="modal-body">
+                <p>This link will open in a new tab. Would you like to proceed?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button id="openTab" type="button" class="btn btn-primary">Proceed</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    $('#newTabNotice').on('show.bs.modal', function (event) {
+        var button = $(event.relatedTarget);
+        var href = button.data('href');
+        
+        var modal = $(this);
+        modal.find('#openTab').off('click').on('click', function () {
+            window.open(href, '_blank');
+            modal.modal('hide');
+        });
+    });
+</script>
 
         <script src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/js/script.js"></script>
         <script src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/js/google_map.js"></script>

--- a/theme/coimbra/views/header.php
+++ b/theme/coimbra/views/header.php
@@ -84,9 +84,8 @@
 </head>
 
 <body>
-    <div id="loader">
-        <img class="logo" src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/images/logo.png"  alt="Coimbra Group Logo">
-        <h1>Coimbra Exhibition</h1>
+    <div class="skip-links">
+        <a class="screen-reader-text" href="<?php echo current_url(); ?>#content">Skip to content</a>
     </div>
     <nav class="navbar navbar-fixed-top">
         <div class="container-fluid">
@@ -96,7 +95,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="https://www.coimbra-group.eu/" title="Coimbra Group Website link" target="_blank"></a>
+                <a class="navbar-brand" href="" title="Coimbra Group Website link" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="https://www.coimbra-group.eu/"></a>
             </div>
             <div class="collapse navbar-collapse" id="myNavbar">
                 <ul class="nav navbar-nav">

--- a/theme/coimbra/views/index.php
+++ b/theme/coimbra/views/index.php
@@ -10,13 +10,13 @@
     <div class="parallax img6 inactive"></div>
 
     <div class="main-categories">
-        <a class="col-xs-6 col-md-6" href='./search/*:*/Category:%22voyage+%7C%7C%7C+Voyage%22'><div class="border-top"></div>Voyage</a>
-        <a class="col-xs-6 col-md-6" href='./search/*:*/Category:%22discovery+%7C%7C%7C+Discovery%22'><div class="border-top"></div>Discovery</a>
-        <a class="col-xs-6 col-md-6" href='./search/*:*/Category:%22faith+%7C%7C%7C+Faith%22'><div class="border-top"></div>Faith</a>
-        <a class="col-xs-6 col-md-6" href='./search/*:*/Category:%22the+arts+%7C%7C%7C+The+Arts%22'><div class="border-top"></div>The Arts</a>
-        <a class="col-xs-6 col-md-6" href='./search/*:*/Category:%22natural+science+%7C%7C%7C+Natural+Science%22'><div class="border-top"></div>Natural Sciences</a>
-        <a class="col-xs-6 col-md-6" href='./search/*:*/Category:%22war+%26+peace+%7C%7C%7C+War+%26+Peace%22'><div class="border-top"></div>War & Peace</a>
-        <a class="col-xs-12 col-md-12" href='./search/*:*/Category:%22the+wunderkammer+%7C%7C%7C+The+Wunderkammer%22'><div class="border-top"></div>The Wunderkammer</a>
+        <a class="col-xs-6 col-md-4" href='./search/*:*/Category:%22voyage+%7C%7C%7C+Voyage%22'><div class="border-top"></div>Voyage</a>
+        <a class="col-xs-6 col-md-4" href='./search/*:*/Category:%22discovery+%7C%7C%7C+Discovery%22'><div class="border-top"></div>Discovery</a>
+        <a class="col-xs-6 col-md-4" href='./search/*:*/Category:%22faith+%7C%7C%7C+Faith%22'><div class="border-top"></div>Faith</a>
+        <a class="col-xs-6 col-md-4" href='./search/*:*/Category:%22the+arts+%7C%7C%7C+The+Arts%22'><div class="border-top"></div>The Arts</a>
+        <a class="col-xs-6 col-md-4" href='./search/*:*/Category:%22natural+science+%7C%7C%7C+Natural+Science%22'><div class="border-top"></div>Natural Sciences</a>
+        <a class="col-xs-6 col-md-4" href='./search/*:*/Category:%22war+%26+peace+%7C%7C%7C+War+%26+Peace%22'><div class="border-top"></div>War & Peace</a>
+        <a class="col-xs-12 col-md-12 border-b" href='./search/*:*/Category:%22the+wunderkammer+%7C%7C%7C+The+Wunderkammer%22'><div class="border-top"></div>The Wunderkammer</a>
     </div>
 </div>
 

--- a/theme/coimbra/views/record.php
+++ b/theme/coimbra/views/record.php
@@ -84,7 +84,7 @@ $jsonwidth = $jobj['width'];
                     }
                     else {
                         if (stripos($element, "uri") !== FALSE) {
-                            echo '<a href="' . $solr[$element][0] . '" title="URL Links for item" target="_blank">' . $solr[$element][0] . '</a>';
+                            echo '<a href="" title="URL Links for item" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="' . $solr[$element][0] . '">' . $solr[$element][0] . '</a>';
 
                         }
                         else {
@@ -119,7 +119,7 @@ $jsonwidth = $jobj['width'];
                 $t_handle_id = preg_replace('/^.*\//', '',$t_handle);
                 $t_seq = $t_segments[4];
                 $t_uri = './record/' . $t_handle_id . '/' . $t_seq . '/' . $t_filename;
-                $LogoLink = '<a href="' . $institutionUri . '" title="Link to Institution" target="_blank"><img src = "' . $t_uri . '" class="uni-thumbnail" /></a>';
+                $LogoLink = '<a href="" title="Link to Institution" target="_blank" data-toggle="modal" data-target="#newTabNotice" data-href="' . $institutionUri . '"><img src = "' . $t_uri . '" class="uni-thumbnail" /></a>';
 
                 echo $LogoLink;
             }


### PR DESCRIPTION
# Changes Made

- Improve colour contrasts for text and links.
	- **Increased contrast on all text and links that did not pass the webaim contrast checker.**
- Increase all body text to between 12 and 14 point.
	- **The smallest font size is now 16px (12pt).**
- Alert the user to links that open new windows or tabs.
	- **Added a popup that appears every time a link is clicked that opens a new tab that lets the user know and asks if they would like to proceed.**
	- **Used bootstrap modals, so would like some feedback on that.**
- Remove the movement of the Coimbra logo or at the least make users able to pause this.
	- **Removed the loading screen entirely.**
- Add skip to main content option on each page
	- **Skip to main content button added.**
- **Underlined all links**
- **Text alignment changed from justified to left-aligned.**