### PR TITLE
LUC023A-233 Guardbook & Openbooks accessibility fixes + broken link fixes.

### DIFF
--- a/static/guardbook/about.php
+++ b/static/guardbook/about.php
@@ -8,7 +8,7 @@
         </p>
         <h1>Centre for Research Collections</h1>
         <p>
-            Further information about the <a href="http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery/crc" title="Centre for Research Collections" target="_blank">Centre for Research Collections</a>.
+            Further information about the <a href="https://www.ed.ac.uk/visit/museums-galleries/heritage-collections" title="Centre for Research Collections" target="_blank" onclick="return warnNewTab()">Centre for Research Collections</a>.
         </p>
         <h1>The Guardbook</h1>
         <p>The Guardbook was the University Library's last catalogue on paper, before computerisation. It was closed to new

--- a/static/openbooks/about.php
+++ b/static/openbooks/about.php
@@ -1,7 +1,7 @@
 <div class="content">
     <div class="content byEditor about">
         <p>This collection is compiled from readers’ orders for scans, principally in black and white and some in colour. They highlight the range of resources at The University of Edinburgh’s Centre for Research Collections, from Herschel’s music manuscripts, to ‘An Essay on the Character and Cerebral Development of Robert Burns,’ to Charles Lyell’s handwritten notes.
-            The images that have been created by the University's Digital Imaging Unit are freely accessible to all. The PDFs are supplied under a Creative Commons CC-BY License: you may share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Further information is available at <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">http://creativecommons.org/licenses/by/4.0/</a></p>
+            The images that have been created by the University's Digital Imaging Unit are freely accessible to all. The PDFs are supplied under a Creative Commons CC-BY License: you may share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Further information is available at <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank" onclick="return warnNewTab()">http://creativecommons.org/licenses/by/4.0/</a></p>
 
         <h1>University Collections</h1>
         <p>
@@ -10,7 +10,7 @@
         </p>
         <h1>Centre for Research Collections</h1>
         <p>
-            Further information about the <a href="http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery/crc" title="Centre for Research Collections" target="_blank">Centre for Research Collections</a>.
+            Further information about the <a href="http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery/crc" title="Centre for Research Collections" target="_blank" onclick="return warnNewTab()">Centre for Research Collections</a>.
         </p>
 
         <h1>Contact Details</h1>

--- a/theme-local/guardbook/css/style.css
+++ b/theme-local/guardbook/css/style.css
@@ -31,15 +31,16 @@ input, select { vertical-align: middle; }
 /* Default Styles --------------------------------------------------------------------------------------------------------*/
 
 html 							{ -webkit-font-smoothing: antialiased; }
-body 							{ background: #EEEEEE; }
+body 							{ background: #EEEEEE; font-size: 22px;}
 body, select, input, textarea 	{ color: #555; font-family: 'Source Sans Pro', sans-serif; }
 
 h1, h2, h3, h4, h5, h6          { text-rendering: optimizeLegibility; color: #000000; font-weight: bold; }
-h1 								{ font-size: 20px; line-height: 24px; margin: 18px 0 17px 0; position: relative; color: #373B41;}
-h2 								{ font-size: 18px; line-height: 36px; margin: 0 0 0 0; }
-h3 								{ color: #373B41; font-size: 16px; line-height: 18px; margin: 0 0 9px 0; }
+h1 								{ font-size: 25px; line-height: 24px; margin: 18px 0 17px 0; position: relative; color: #373B41;}
+h2 								{ font-size: 23px; line-height: 36px; margin: 0 0 0 0; }
+h3 								{ color: #373B41; font-size: 21px; line-height: 18px; margin: 0 0 9px 0; }
+h5                              {font-size: 16px;}
 
-h1.itemtitle 					{ font-family: 'Special Elite', cursive; font-size: 22px; line-height: 30px;
+h1.itemtitle 					{ font-family: 'Special Elite', cursive; font-size: 27px; line-height: 30px;
     margin: 15px 0 10px 0; position: relative; color: #373B41; }
 .left-title h1.itemtitle, .full-title h1.itemtitle
 { margin-top: 0; padding-top: 10px; }
@@ -47,8 +48,9 @@ h1.itemtitle 					{ font-family: 'Special Elite', cursive; font-size: 22px; line
 h1 a.heading-link               { color: #999; text-decoration: none; }
 h1 a.heading-link:hover         { text-decoration: underline; }
 
-p 								{ font-size: 17px; margin-bottom: 18px; }
+p 								{ font-size: 22px; margin-bottom: 18px; }
 
+a                               {text-decoration: underline;}
 a, a:active, a:visited          { color: #163772; }
 a:hover 						{ text-decoration: underline; color: #999; }
 
@@ -63,9 +65,10 @@ header .container   { padding: 0;}
 /* header */
 .navbar             { margin-bottom: 0;}
 
+.navbar-default .navbar-nav > li > a { color: #3c3c3c;  text-decoration: none;}
 .navbar-default .navbar-nav > li > a:focus, .navbar-default .navbar-nav > li > a:hover { background-color: #a50034; color: #FFFFFF;  }
 
-.navbar-default     { background-color: #999; border: 0;  }
+.navbar-default     { background-color: #999; border: 0;}
 
 .uoe-logo {
     display: block;
@@ -87,12 +90,12 @@ header .container   { padding: 0;}
     font-family: 'IM Fell DW Pica', serif;
     font-weight: 700;
     font-style: normal;
-    font-size: 42px;
+    font-size: 47px;
     line-height: 30px;
     padding-top: 15px;
     padding-left: 30px;}
 
-#collection-sub-title       { font-size: 24px;  line-height: 28px;  }
+#collection-sub-title       { font-size: 29px;  line-height: 28px;  }
 #collection-title a         { text-decoration: none; color: #a50034;}
 #collection-title a:hover   { text-decoration: none; color: #008046;}
 #collection-search          { float: right; }
@@ -104,9 +107,21 @@ header .container   { padding: 0;}
     padding-left: 0;
 }
 
+.list-group-item>.badge {
+    background-color: #3c3c3c;
+}
+
+.text-muted {
+    color: #3c3c3c;
+}
+
+.form-control {
+    font-size: 19px;
+}
+
 #menu                           { width: 940px; background-color: #EEEDE8; margin: 0 auto; height: 33px; }
 .menu-links li					{ display: inline; float: right; height: 33px; padding-left: 0; padding-right: 0; }
-.menu-links li a 			    { font-weight: bold; font-size: 11px; text-transform: uppercase; float: left;
+.menu-links li a 			    { font-weight: bold; font-size: 16px; text-transform: uppercase; float: left;
     text-decoration: none; margin-left: 10px; color: #666666; display: inline-block;
     height: 33px; line-height: 2.5em; padding-left: 20px; padding-right: 20px;text-align: center; }
 .menu-links li a:hover		    { background-color: #a50034; color: #FFFFFF;}
@@ -125,7 +140,7 @@ header .container   { padding: 0;}
 
 .item-div                       { width: 660px; text-align: left; display: block; }
 .iteminfo                       { display: block; min-height:40px; text-align: left; width: 100%; float:left; }
-.iteminfo h3                    { font-size: 20px; margin-top: 5px; }
+.iteminfo h3                    { font-size: 25px; margin-top: 5px; }
 .sort                           { float: right;  text-align: right; }
 
 /** side panel */
@@ -156,11 +171,11 @@ footer                          { padding-top: 10px; padding-bottom: 10px;}
 
 .footer-logos                   { padding-bottom: 20px; }
 
-.footer-policies                { font-size: 14px; margin-bottom: 5px; color: #555555;  text-align: center;}
+.footer-policies                { font-size: 19px; margin-bottom: 5px; color: #555555;  text-align: center;}
 
-.footer-policies a, a:active, a:visited         { color: #a50034; text-decoration: none;}
+.footer-policies a, a:active, a:visited         { color: #a50034;}
 .footer-policies a:hover 						{ text-decoration: underline; color: #008046;}
-.footer-copyright                               { font-size: 11px;}
+.footer-copyright                               { font-size: 16px;}
 
 .index-img {
     padding-bottom: 20px;
@@ -178,7 +193,7 @@ footer                          { padding-top: 10px; padding-bottom: 10px;}
 /* Custom Containers & Subclasses ----------------------------------------------------------------------------------------*/
 
 .tags					            { margin-top: 5px;  }
-.tags a 				            { color: #fff; font-size: 15px; background: #999; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; margin-top: 6px; text-decoration: none; display:inline-block; }
+.tags a 				            { color: #fff; font-size: 20px; background: #999; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; margin-top: 6px; text-decoration: none; display:inline-block; }
 .tags a.bold			            { font-weight: bold; }
 .tags a:hover			            { background: #a50034; color: #ffffff; text-decoration: none; }
 .tags a:visited			            { background: #a50034; color: #ffffff; text-decoration: none; }
@@ -251,4 +266,90 @@ q:after                             { content: close-quote;  }
     h2, h3{ page-break-after: avoid; }
 }
 
+/* ---------------------
 
+        Hilighter
+
+------------------------*/
+
+.form-control:focus-visible, 
+button:focus-visible, 
+button:focus, 
+input:focus-visible, 
+a:focus-visible {
+    position: relative;
+}
+
+.form-control:focus-visible:after, 
+button:focus-visible:after, 
+button:focus:after, 
+input:focus-visible:after, 
+a:focus-visible:after {
+    content: "";
+    position: absolute;
+    top: -2px;
+    left: -2px;
+    right: -2px;
+    bottom: -2px;
+    outline: 4px solid #ffd900;
+    outline-offset: -3px;
+    box-shadow: 0 0 0 4px #a50034;
+    pointer-events: none;
+    z-index: 1;
+    display: block;
+}
+
+a:focus-visible {
+    display: inline-block;
+    overflow: visible;
+}
+
+a div:focus-visible {
+    outline: 4px solid #ffd900;
+    outline-offset: 4px;
+    box-shadow: 0 0 0 8px #a50034;
+}
+
+.form-control:focus-visible,
+input:focus-visible,
+select:focus-visible,
+input:focus,
+.pdfviewer:focus-within {
+    outline: 4px solid #ffd900;
+    box-shadow: 0 0 0 8px #a50034;
+}
+
+/* ---------------------
+
+      Skip to Main
+
+------------------------*/
+.screen-reader-text {
+    position: absolute !important;
+    clip-path: circle(0%);
+    border: 0;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    width: 1px;
+    word-wrap: normal!important;
+}
+
+.screen-reader-text:hover, .screen-reader-text:active, .screen-reader-text:focus {
+    z-index: 100000;
+    top: 5px;
+    left: 5px;
+    display: block;
+    width: auto;
+    height: auto;
+    text-decoration: none;
+    color: black;
+    border-radius: 3px;
+    background-color: #ffffff;
+    font-size: 12pt;
+    font-weight: bold;
+    line-height: normal;
+    clip-path: circle(100%);
+    padding: 8px;
+}

--- a/theme-local/openbooks/css/style.css
+++ b/theme-local/openbooks/css/style.css
@@ -35,7 +35,7 @@ time, mark, audio, video {
   margin: 0;
   padding: 0;
   border: 0;
-  font-size: 100%;
+  font-size: 16px;
   font: inherit;
   vertical-align: baseline;
 }
@@ -56,7 +56,6 @@ input, select { vertical-align: middle; }
 
 
 /* Font normalization inspired by YUI Library's fonts.css: developer.yahoo.com/yui/ */
-body 					 			{ font:13px/1.231 sans-serif; *font-size:small; } /* Hack retained to preserve specificity */
 select, input, textarea, button 	{ font:99% sans-serif; }
 
 pre, code, kbd, samp 				{ font-family: monospace, sans-serif; } /* Normalize monospace sizing: en.wikipedia.org/wiki/MediaWiki_talk:Common.css/Archive_11#Teletype_style_fix_for_Chrome */
@@ -106,29 +105,29 @@ body 							{ background: #fff }
 body, select, input, textarea 	{ color: #555; line-height: 18px; font-family: Arial, Helvetica, sans-serif; }
 
 h1, h2, h3, h4, h5, h6 			{ text-rendering: optimizeLegibility; color: #444f51; font-weight: bold; }
-h1 								{ font-size: 18px; line-height: 24px; margin: 30px 0 17px 0px; position: relative; }
-h2 								{ font-size: 16px; line-height: 36px; margin: 0 0 0 0; }
-h3 								{ font-size: 14px; line-height: 18px; margin: 0 0 5px 0; }
+h1 								{ font-size: 24px; line-height: 24px; margin: 30px 0 17px 0px; position: relative; }
+h2 								{ font-size: 22px; line-height: 36px; margin: 0 0 0 0; }
+h3 								{ font-size: 20px; line-height: 18px; margin: 0 0 5px 0; }
 
-h1.itemtitle                    { font-size: 18px; line-height: 24px; margin: 20px 0 10px 0px; position: relative; }
+h1.itemtitle                    { font-size: 30px; line-height: 24px; margin: 20px 0 10px 0px; position: relative; }
 
-p 								{ font-size: 13px; margin-bottom: 18px; }
+p 								{ font-size: 19px; margin-bottom: 18px; }
 
 a, a:active, a:visited 			{ color: #444f51; }
 a:hover 						{ color: #761400; }
 
 input[type=text], input[type=password]				{
-	border: 1px solid #bbbbbc; font-size: 13px; height: 28px; padding: 0 10px;
+	border: 1px solid #bbbbbc; font-size: 19px; height: 28px; padding: 0 10px;
 	-webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px;
 }
 input.btn						{
-	background: #444f51; border: none; height: 28px; color: #fff; text-transform: uppercase; font-size: 14px; margin-left: 8px; font-weight: bold; padding: 0 18px;
+	background: #444f51; border: none; height: 28px; color: #fff;  font-size: 20px; margin-left: 8px; font-weight: bold; padding: 0 18px;
 	-webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; text-shadow: rgba(0,0,0,0.3) 0px -1px 0px;
 }
 input.btn:hover					{ background: #761400; }
 
 input.backbtn				    {
-    background: #444f51; border: none; height: 24px; color: #fff; text-transform: uppercase; font-size: 12px; margin-left: 8px; font-weight: bold; padding: 0 10px;
+    background: #444f51; border: none; height: 24px; color: #fff;  font-size: 18px; margin-left: 8px; font-weight: bold; padding: 0 10px;
     margin-top: 10px; margin-bottom: 10px;
     -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; text-shadow: rgba(0,0,0,0.3) 0px -1px 0px;
 }
@@ -145,12 +144,12 @@ header				{ position: relative; }
 
 #menu                               { width: 940px; background-color: #333333; margin: 0 auto; height: 33px; }
 .menu-links li					    { display: inline; float: right; height: 33px; padding-left: 0; padding-right: 0; }
-.menu-links li a 			        { font-weight: bold; font-size: 11px; text-transform: uppercase; float: left; text-decoration: none; margin-left: 10px; color: #FFFFFF; display: inline-block; height: 33px; line-height: 2.5em; padding: 3px 20px 2px; text-align: center; }
+.menu-links li a 			        { font-weight: bold; font-size: 17px;  float: left; text-decoration: none; margin-left: 10px; color: #FFFFFF; display: inline-block; height: 33px; line-height: 2.5em; padding: 3px 20px 2px; text-align: center; }
 .menu-links li a:hover		        { background-color: #ffffff; color: #333333}
 .menu-links li a.last		        { border: none; }
 
 .uoe-links li                       { display: block; float: left; height: 33px; padding-left: 0; padding-right: 0; }
-.uoe-links li a                     { font-weight: bold; font-size: 11px; text-transform: uppercase; float: left; text-decoration: none; margin-left: 0px; color: #FFFFFF; display: inline-block; height: 33px; line-height: 2.5em; padding: 3px 20px 2px; text-align: center; }
+.uoe-links li a                     { font-weight: bold; font-size: 17px;  float: left; text-decoration: none; margin-left: 0px; color: #FFFFFF; display: inline-block; height: 33px; line-height: 2.5em; padding: 3px 20px 2px; text-align: center; }
 .uoe-links li a:hover		        { background-color: #ffffff; color: #333333}
 
 
@@ -175,43 +174,47 @@ a.oblogo span {
     top: 33px;
     left: 233px;
     width: 429px;
-    padding: 20px;
-    background: #fff;
+    padding: 26px 0;
+    background: #ffffff9d;
+    backdrop-filter: blur(5px);
     color: #444f51;
-    text-transform: uppercase;
     font-weight: bold;
     font-size: 60px;
     text-align: center;
-    opacity: 0.8;
+}
+
+a.oblogo span:hover {
+    background: #7614009d;
+    color: #fff;
 }
 
 a.oblogo:hover span {
     display: block;
 }
 
-.search							{ padding-bottom: 20px; border-bottom: 1px solid #444f51; width: 660px; }
+.search							{ padding-bottom: 20px; border-bottom: 1px solid #444f51; width: 660px; display: flex; align-items: center;}
 .search input[type=text]		{ 
 	box-shadow: 0px 0px 9px rgba(178,179,180, 0.3); -moz-box-shadow: 0px 0px 9px rgba(178,179,180, 0.75); -webkit-box-shadow: 0px 0px 9px rgba(178,179,180, 0.3); 
-	font-size: 16px; color: #444f51; font-weight: bold; padding-left: 33px; width: 390px;
+	font-size: 22px; color: #444f51; font-weight: bold; padding-left: 33px; width: 390px;
 	background: #fff url(../images/bg-search.png) no-repeat 0px 0px;
 }
 .ie7 .search input[type=text]	{ width: 355px; }
 .search input.btn				{ margin-right: 8px; }
-.search .advanced 				{ text-transform: uppercase; font-size: 10px; text-decoration: none; }
+.search .advanced 				{ font-size: 16px; text-align: center;}
 .search .advanced:hover			{ text-decoration: underline; }
 
 .header-links 					{ position: absolute; top: 16px; left: 0; overflow: hidden; }
-.header-links a 				{ font-size: 10px; text-transform: uppercase; float: left; text-decoration: none; padding-right: 10px; margin-right: 10px; border-right: 1px solid #b8c1c6; line-height: 12px;  }
+.header-links a 				{ font-size: 16px;  float: left; text-decoration: none; padding-right: 10px; margin-right: 10px; border-right: 1px solid #b8c1c6; line-height: 12px;  }
 .header-links a:hover			{ text-decoration: underline; }
 .header-links a.last			{ border: none; }
 
-.col-sidebar h4                 {color: #fff; line-height: 26px; font-weight: bold; text-transform: uppercase; font-size: 12px; margin-bottom: 17px; background: #444f51; padding: 0 17px; }
+.col-sidebar h4                 {color: #fff; line-height: 26px; font-weight: bold;  font-size: 18px; margin-bottom: 17px; background: #444f51; padding: 0 17px; }
 .col-sidebar h4 a               {
     background: #444f51; url(../images/bg-arrows.png) no-repeat 100% -92px;
     display: block; color: #fff; text-decoration: none; width: 223px; padding-left: 17px; position: relative; left: -17px;
 }
 .col-sidebar h4 a:hover         { background: #761400 url(../images/bg-arrows.png) no-repeat 100% -92px; }
-.col-sidebar ul                 { list-style-type: none; margin: 2px 2px 25px 2px; font-size: 12px; }
+.col-sidebar ul                 { list-style-type: none; margin: 2px 2px 25px 2px; font-size: 18px; }
 .col-sidebar ul li              { line-height: 16px; margin-top: 5px; padding: 0 17px; }
 .col-sidebar ul a               { text-decoration: none; display: block; }
 .col-sidebar ul a:hover         { text-decoration: underline; }
@@ -231,11 +234,11 @@ a.oblogo:hover span {
 .col-sidebar ul.related .tags a 			{ padding: 2px 5px; display: inline-block; background: #ffffff; color: #444f51;}
 .col-sidebar ul.related .tags a:hover		{ text-decoration: none; background: #444f51; color: #fff; }
 
-.col-sidebar ul.related li a.related-record { font-size: 14px; padding-bottom: 5px;}
+.col-sidebar ul.related li a.related-record { font-size: 20px; padding-bottom: 5px;}
 
 
 .tags					{ margin: 0 0 0 0; }
-.tags a 				{ font-size: 13px; background: #cecece; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
+.tags a 				{ font-size: 19px; background: #cecece; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
 .tags a.bold			{ font-weight: bold; }
 .tags a:hover			{ background: #e7e8ea; color: #761400; }
 
@@ -245,7 +248,7 @@ footer a:hover				{ color: #333 !important; text-decoration: underline; }
 
 
 .site-links			        { display: block; padding-top: 10px; padding-bottom: 10px; width: 520px; float: left; }
-.site-links a 		        { font-size: 10px; text-transform: uppercase; color: #AAA79E  !important; text-decoration: none; font-weight: bold;  padding-right: 15px; margin-right: 10px; border-right: 1px solid #cecece;}
+.site-links a 		        { font-size: 16px;  color: #5e5e5e  !important; text-decoration: none; font-weight: bold;  padding-right: 15px; margin-right: 10px; border-right: 1px solid #cecece;}
 .site-links a.border	    { border-right: 1px solid #cecece;}
 .site-links a.last	        { border: none; }
 .site-links a:hover	        { text-decoration: underline; color: #761400; }
@@ -267,7 +270,7 @@ footer a:hover				{ color: #333 !important; text-decoration: underline; }
 .islogo                 { display: block; float: left; width: 50px; height: 64px; background: url(../images/islogo.gif) no-repeat 0px 0px; }
 
 .footer-policies        { display: block; float: left; padding-left: 10px; }
-.footer-policies p      { font-size: 12px; margin-bottom: 5px; color: #555555}
+.footer-policies p      { font-size: 18px; margin-bottom: 5px; color: #555555}
 .obooks-tile                { float: left; display: block;}
 .ccbylogo               { display: block; width: 100px; height: 35px; background: url(../images/ccby.jpg) no-repeat 0px 0px;text-align: center; }
 
@@ -296,15 +299,15 @@ footer a:hover				{ color: #333 !important; text-decoration: underline; }
 
 .listing li h3 						{ margin-bottom: 8px; }
 .listing li .tags					{ margin: 0 0 8px 0; }
-.listing li .tags a 				{ font-size: 12px; }
+.listing li .tags a 				{ font-size: 18px; }
 .listing li .tags a:hover			{ text-decoration: none; }
 .listing li h3                      { margin-bottom: 8px; }
-.listing li p 						{ font-size: 12px; margin: 0; }
+.listing li p 						{ font-size: 18px; margin: 0; }
 
 .listing-filter						{ padding: 0; border: none; border-bottom: 1px solid #444f51; line-height: 33px; text-align: right; position: relative; }
 .listing-filter .no-results			{ position: absolute; top: 0; left: 0; }
 .ie7 .listing-filter .no-results	{ top: -10px; }
-.listing-filter .sort				{ font-size: 10px; text-transform: uppercase; color: #761400; padding-right: 10px; }
+.listing-filter .sort				{ font-size: 16px;  color: #761400; padding-right: 10px; }
 .listing-filter .sort a 			{ text-decoration: none; }
 .listing-filter .sort a:hover		{ text-decoration: underline; }
 .listing-filter .sort strong		{ color: #333; }
@@ -334,12 +337,12 @@ h1 .icon							{ top: -5px; left: -65px; }
 .small-icon.media-img				{ background-position: 0px -40px; }
 .small-icon.media-book				{ background-position: 0px -60px; }
 
-.pagination							{ border-top: 0; line-height: 33px; text-align: center; position: relative; font-size: 11px; font-weight: bold; }
+.pagination							{ border-top: 0; line-height: 33px; text-align: center; position: relative; font-size: 17px; font-weight: bold; }
 .pagination a 						{ color: #761400; text-decoration: none; display: inline-block; padding: 0 5px; }
 .pagination a.selected 				{ background: #e8e8e8; color: #333; }
 .pagination a:hover					{ color: #333; text-decoration: underline; }
 .pagination .prev,
-.pagination .next					{ display: block; position: absolute; top: 0; font-size: 11px; background: url(../images/bg-arrows.png) no-repeat 0px 0px; }
+.pagination .next					{ display: block; position: absolute; top: 0; font-size: 17px; background: url(../images/bg-arrows.png) no-repeat 0px 0px; }
 .pagination .prev					{ left: 0; padding: 0 10px 0 25px; }
 .pagination .next					{ right: 0; padding: 0 25px 0 10px; background-position: 100% -33px !important; }
 .pagination .prev:hover,
@@ -349,7 +352,7 @@ h1 .icon							{ top: -5px; left: -65px; }
 .content ul 						{ margin: 0 0 18px 1.2em; }
 
 table								{ width: 100%; background: #fff; }
-table caption						{ text-align: left; background: #677077; color: #fff; font-size: 12px; text-transform: uppercase; font-weight: bold; padding: 8px 17px; border-bottom: 1px solid #fff;  }
+table caption						{ text-align: left; background: #677077; color: #fff; font-size: 18px;  font-weight: bold; padding: 8px 17px; border-bottom: 1px solid #fff;  }
 table td,
 table th							{ text-align: left; border-right: 1px solid #fff;  }
 table tr:nth-child(2n)				{ background: #fff; }
@@ -493,7 +496,7 @@ table tr:last-child                 { border: 0; border-bottom: none; }
 .listing li a.downloadButton, a.downloadButton:visited
 {
     float: right;
-    border: none; height: 18px; color: #fff; text-transform: uppercase; font-size: 12px; text-decoration: none; font-weight: bold; padding: 5px 10px;
+    border: none; height: 18px; color: #fff;  font-size: 18px; text-decoration: none; font-weight: bold; padding: 5px 10px;
     -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; text-shadow: rgba(0,0,0,0.3) 0 -1px 0;
     background: url("../images/bg-arrows2.png") no-repeat scroll 100% 0px #444f51;
     padding-right: 24px;
@@ -506,7 +509,7 @@ table tr:last-child                 { border: 0; border-bottom: none; }
     text-decoration: none;
     background: url("../images/bg-arrows2.png") no-repeat scroll 100% 0px #761400;
 }
-.record-bitstreams          { display: block; width: 330px; margin: 5px 0; text-align: right; float: right; font-size: 13px;}
+.record-bitstreams          { display: block; width: 330px; margin: 5px 0; text-align: right; float: right; font-size: 19px;}
 .record-bitstreams a:hover  { color: #999; }
 
 
@@ -518,12 +521,12 @@ table tr:last-child                 { border: 0; border-bottom: none; }
     padding-top: 20px;
     text-align: center;
     text-shadow: none;
-    text-transform: uppercase;
+    
     z-index: 10;
 
     /* styling below */
     background-color: #444f51;
-    font-size: 14px;
+    font-size: 20px;
     font-weight: bold;
     /* opacity: 0.80; /* transparency */
     /* filter: alpha(opacity=80); /* IE transparency */
@@ -537,3 +540,90 @@ table tr:last-child                 { border: 0; border-bottom: none; }
 
 .italic { font-style: italic; }
 .bold { font-weight: bold; }
+
+/* ---------------------
+
+        Hilighter
+
+------------------------*/
+
+.form-control:focus-visible, 
+button:focus-visible, 
+button:focus, 
+input:focus-visible, 
+a:focus-visible {
+    position: relative;
+}
+
+.form-control:focus-visible:after, 
+button:focus-visible:after, 
+button:focus:after, 
+input:focus-visible:after, 
+a:focus-visible:after {
+    content: "";
+    position: absolute;
+    top: -2px;
+    left: -2px;
+    right: -2px;
+    bottom: -2px;
+    outline: 4px solid #ffd900;
+    outline-offset: -3px;
+    box-shadow: 0 0 0 4px #761400;
+    pointer-events: none;
+    z-index: 1;
+    display: block;
+}
+
+a:focus-visible {
+    display: inline-block;
+    overflow: visible;
+}
+
+a div:focus-visible {
+    outline: 4px solid #ffd900;
+    outline-offset: 4px;
+    box-shadow: 0 0 0 8px #761400;
+}
+
+.form-control:focus-visible,
+input:focus-visible,
+select:focus-visible,
+input:focus {
+    outline: 4px solid #ffd900;
+    box-shadow: 0 0 0 8px #761400;
+}
+
+/* ---------------------
+
+      Skip to Main
+
+------------------------*/
+.screen-reader-text {
+    position: absolute !important;
+    clip-path: circle(0%);
+    border: 0;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    width: 1px;
+    word-wrap: normal!important;
+}
+
+.screen-reader-text:hover, .screen-reader-text:active, .screen-reader-text:focus {
+    z-index: 100000;
+    top: 5px;
+    left: 5px;
+    display: block;
+    width: auto;
+    height: auto;
+    text-decoration: none;
+    color: black;
+    border-radius: 3px;
+    background-color: #fff;
+    font-size: 12pt;
+    font-weight: bold;
+    line-height: normal;
+    clip-path: circle(100%);
+    padding: 8px;
+}

--- a/theme/clds/views/footer.php
+++ b/theme/clds/views/footer.php
@@ -25,7 +25,7 @@
                         <ul>
                             <li><a href="./accessibility">Website accessibility</a></li>
                             <li><a href="https://www.ed.ac.uk/about/website/freedom-information">Freedom of information publication scheme</a></li>
-                            <li><a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/services/copying-and-digitisation/image-licensing/takedown-policy" target="_blank" title="Takedown Policy">Takedown Policy</a></li>
+                            <li><a href="https://www.ed.ac.uk/information-services/library-museum-gallery/heritage-collections/using-the-collections/digitisation/image-licensing/takedown-policy" target="_blank" title="Takedown Policy">Takedown Policy</a></li>
                         </ul>
                     </div>
                     <div class="col-sm-4 col-xs-6">

--- a/theme/eerc/views/footer.php
+++ b/theme/eerc/views/footer.php
@@ -12,7 +12,7 @@
                 <div class="col-sm-12 col-xs-12 footer-disclaimer">
                     <div class="center-block footer-policies">
                         <a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank" onclick="return warnNewTab()">Privacy &amp; Cookies</a>
-                        &nbsp;&nbsp;<a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/services/copying-and-digitisation/image-licensing/takedown-policy" target="_blank" onclick="return warnNewTab()" title="Takedown Policy Link">Takedown Policy</a>
+                        &nbsp;&nbsp;<a href="https://www.ed.ac.uk/information-services/library-museum-gallery/heritage-collections/using-the-collections/digitisation/image-licensing/takedown-policy" target="_blank" onclick="return warnNewTab()" title="Takedown Policy Link">Takedown Policy</a>
                         &nbsp;&nbsp;<a href="./using" title="Licensing and Copyright Link">Licensing &amp; Copyright</a>
                         &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank" onclick="return warnNewTab()">Accessibility</a>
                         <p class="footer-copyright">Unless explicitly stated otherwise, all material is copyright &copy; <?php echo date("Y"); ?> <a href="https://www.ed.ac.uk" title="University of Edinburgh Home" target="_blank" onclick="return warnNewTab()">University of Edinburgh</a>.</p>

--- a/theme/guardbook/views/feedback.php
+++ b/theme/guardbook/views/feedback.php
@@ -1,0 +1,30 @@
+<?php
+$email_address = $this->config->item('skylight_adminemail');
+?>
+<div class="feedback_form">
+
+    <h1>Feedback</h1>
+
+    <p>Please contact us with your suggestions or questions at <a class="para-link" href="mailto:<?php echo $email_address ?>"><?php echo $email_address ?></a>.</p>
+
+
+    <h3>Privacy Statement </h3>
+    <p>Information about you: how we use it and with whom we share it
+    </p>
+    <p>
+        The information you provide in this form will be used only for purposes of your enquiry. We will not share your personal information with any third party or use it for any other purpose.
+        We are using information about you because it is necessary to contact you regarding your enquiry. By providing your personal data when submitting an enquiry to us, consent for your personal data to be used in this way is implied.
+    </p>
+    <p>
+        For digitisation orders, your personal data is necessary for the performance of our contract to provide you with services that charge a fee.
+    </p>
+    <p>
+        We will hold the personal data you provided us for 6 years. We do not use profiling or automated decision-making processes.
+    </p>
+    <p>
+        If you have any questions, please contact: <a class="para-link" href="mailto:<?php echo $email_address ?>"><?php echo $email_address ?></a>
+    </p>
+    <p><a class="para-link" href="https://www.ed.ac.uk/about/website/privacy" target="_blank" onclick="return warnNewTab()" onclick="return warnNewTab()">University privacy statement</a></p>
+
+
+</div>

--- a/theme/guardbook/views/footer.php
+++ b/theme/guardbook/views/footer.php
@@ -3,11 +3,11 @@
             <footer>
                 <div class="col-sm-12 col-xs-12 footer-disclaimer">
                     <div class="center-block footer-policies">
-                        <a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank">Privacy &amp; Cookies</a>
-                        &nbsp;&nbsp;<a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/services/copying-and-digitisation/image-licensing/takedown-policy" target="_blank" title="Takedown Policy Link">Takedown Policy</a>
+                        <a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank" onclick="return warnNewTab()">Privacy &amp; Cookies</a>
+                        &nbsp;&nbsp;<a href="https://www.ed.ac.uk/information-services/library-museum-gallery/heritage-collections/using-the-collections/digitisation/image-licensing/takedown-policy" target="_blank" onclick="return warnNewTab()" title="Takedown Policy Link">Takedown Policy</a>
                         &nbsp;&nbsp;<a href="./licensing" title="Licensing and Copyright Link">Licensing &amp; Copyright</a>
-                        &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank">Accessibility</a>
-                        <p class="footer-copyright">Unless explicitly stated otherwise, all material is copyright &copy; <?php echo date("Y"); ?> <a href="https://www.ed.ac.uk" title="University of Edinburgh Home" target="_blank">University of Edinburgh</a>.</p>
+                        &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank" onclick="return warnNewTab()">Accessibility</a>
+                        <p class="footer-copyright">Unless explicitly stated otherwise, all material is copyright &copy; <?php echo date("Y"); ?> <a href="https://www.ed.ac.uk" title="University of Edinburgh Home" target="_blank" onclick="return warnNewTab()">University of Edinburgh</a>.</p>
                     </div>
                 </div>
             </footer>

--- a/theme/guardbook/views/header.php
+++ b/theme/guardbook/views/header.php
@@ -84,6 +84,15 @@
 </head>
 
     <body>
+        <div class="skip-links">
+            <a class="screen-reader-text" href="<?php echo current_url(); ?>#content">Skip to content</a>
+        </div>
+        <!-- New tab notice script -->
+        <script>
+            function warnNewTab() {
+              return confirm("This link will open in a new tab. Proceed?");
+            }
+        </script>
         <nav class="navbar navbar-default">
             <div class="container">
                 <div class="uoe-logo"></div>
@@ -125,4 +134,4 @@
             </div>
         </header>
 
-        <div class="container content">
+        <div id="content" class="container content">

--- a/theme/guardbook/views/index.php
+++ b/theme/guardbook/views/index.php
@@ -32,8 +32,7 @@
     <div class="clearfix"></div>
     <img src="<?php echo base_url()?>theme/guardbook/images/CC-BY_icon.png" alt="CC-BY attribution license" class="img-responsive" />
     <p>
-        The PDFs are supplied under a Creative Commons CC-BY License: you may share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Further information is available at <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">http://creativecommons.org/licenses/by/4.0/</a>
-    <div id="ccby"><a href ="https://creativecommons.org/licenses/by/4.0/" target ="_blank" alt ="Creative Commons info" class ="ccbylogo"></a></div>
+        The PDFs are supplied under a Creative Commons CC-BY License: you may share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Further information is available at <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank" onclick="return warnNewTab()">http://creativecommons.org/licenses/by/4.0/</a>
 
     </p>
 </div>

--- a/theme/guardbook/views/record.php
+++ b/theme/guardbook/views/record.php
@@ -102,7 +102,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
             <!--<br>
             <iframe src="<?//php echo base_url(); ?>theme/<?php // echo $this->config->item('skylight_theme'); ?>/addons/PDF_Viewer/pdf_reader.php?url=<?php// echo base_url() .$this->config->item('skylight_theme')."/". $b_uri ?>" title="PDF Viewer" width="700" height="900"></iframe>
             <br>-->
-            Click <?php echo '<a href ="'.$bitstreamLink.'" target="_blank">'.$b_filename.'</a>'?> to download.
+            Click <?php echo '<a href ="'.$bitstreamLink.'" target="_blank" onclick="return warnNewTab()">'.$b_filename.'</a>'?> to download.
             (<span class="bitstream_size"><?php echo getBitstreamSize($bitstream); ?></span>)<br><br>
             <?php
         }
@@ -113,7 +113,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
     <div class="clearfix"></div>
     <img src="<?php echo base_url()?>theme/guardbook/images/CC-BY_icon.png" alt="CC-BY attribution license" class="img-responsive" />
     <p>
-        The PDFs are supplied under a Creative Commons CC-BY License: you may share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Further information is available at <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">http://creativecommons.org/licenses/by/4.0/</a>
+        The PDFs are supplied under a Creative Commons CC-BY License: you may share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Further information is available at <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank" onclick="return warnNewTab()">http://creativecommons.org/licenses/by/4.0/</a>
     <div id="ccby"><a href ="https://creativecommons.org/licenses/by/4.0/" target ="_blank" alt ="Creative Commons info" class ="ccbylogo"></a></div>
 
     </p>

--- a/theme/openbooks/views/div_main_end.php
+++ b/theme/openbooks/views/div_main_end.php
@@ -7,25 +7,25 @@
                 </div>
                 <div class="social-links">
                     <ul class="social-icons">
-                        <li><a href="https://www.facebook.com/crc.edinburgh" class="facebook-icon" target="_blank" title="CRC on Facebook"></a></li>
-                        <li><a href="https://twitter.com/CRC_EdUni" class="twitter-icon" target="_blank" title="CRC on Twitter"></a></li>
+                        <li><a href="https://www.facebook.com/crc.edinburgh" class="facebook-icon" target="_blank" onclick="return warnNewTab()" title="CRC on Facebook"></a></li>
+                        <li><a href="https://twitter.com/CRC_EdUni" class="twitter-icon" target="_blank" onclick="return warnNewTab()" title="CRC on Twitter"></a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-disclaimer">
                 <div class="footer-logo">
-                    <a href="https://www.ed.ac.uk/schools-departments/information-services/about/organisation/library-and-collections" target="_blank" class="luclogo" title="Library &amp; University Collections Home"></a>
+                    <a href="https://www.ed.ac.uk/schools-departments/information-services/about/organisation/library-and-collections" target="_blank" onclick="return warnNewTab()" class="luclogo" title="Library &amp; University Collections Home"></a>
                 </div>
                 <div class="footer-policies">
                     <p>This collection is part of <a href="<?php echo base_url(); ?>" title="University Collections Home">University Collections</a>.</p>
-                    <p><a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank">Privacy &amp; Cookies</a>
-                        &nbsp;&nbsp;<a href="https://www.ed.ac.uk/information-services/library-museum-gallery/crc/services/copying-and-digitisation/image-licensing/takedown-policy" target="_blank" title="Takedown Policy Link">Takedown Policy</a>
+                    <p><a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank" onclick="return warnNewTab()">Privacy &amp; Cookies</a>
+                        &nbsp;&nbsp;<a href="https://www.ed.ac.uk/information-services/library-museum-gallery/heritage-collections/using-the-collections/digitisation/image-licensing/takedown-policy" target="_blank" onclick="return warnNewTab()" title="Takedown Policy Link">Takedown Policy</a>
                         &nbsp;&nbsp;<a href="./licensing" title="Licensing and Copyright Link">Licensing &amp; Copyright</a>
-                        &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank">Accessibility</a></p>
-                    <p>Unless explicitly stated otherwise, all material is copyright &copy; <?php echo date("Y"); ?> <a href="https://www.ed.ac.uk" title="University of Edinburgh Home" target="_blank">University of Edinburgh</a>.</p>
+                        &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank" onclick="return warnNewTab()">Accessibility</a></p>
+                    <p>Unless explicitly stated otherwise, all material is copyright &copy; <?php echo date("Y"); ?> <a href="https://www.ed.ac.uk" title="University of Edinburgh Home" target="_blank" onclick="return warnNewTab()">University of Edinburgh</a>.</p>
                 </div>
                 <div class="is-logo">
-                    <a href="https://www.ed.ac.uk/information-services" target="_blank" class="islogo" title="University of Edinburgh Information Services Home"></a>
+                    <a href="https://www.ed.ac.uk/information-services" target="_blank" onclick="return warnNewTab()" class="islogo" title="University of Edinburgh Information Services Home"></a>
                 </div>
             </div>
         </footer>

--- a/theme/openbooks/views/header.php
+++ b/theme/openbooks/views/header.php
@@ -87,21 +87,29 @@
 </head>
 
 <body>
-
+<!-- New tab notice script -->
+<script>
+    function warnNewTab() {
+        return confirm("This link will open in a new tab. Proceed?");
+    }
+</script>
+<div class="skip-links">
+    <a class="screen-reader-text" href="<?php echo current_url(); ?>#main">Skip to content</a>
+</div>
 <div id="container">
     <header>
         <div id="collection-title">
             <a href="<?php echo base_url(); ?>" class="oblogo" title="University of Edinburgh Open Books Collection Home">
-                <span onmouseover="this.style.background='#761400';this.style.color='#FFF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#444f51'"><?php echo $site_title; ?></span>
+                <span><?php echo $site_title; ?></span>
             </a>
-            <a href="https://www.ed.ac.uk" class="uoelogo" title="The University of Edinburgh Home" target="_blank"></a>
+            <a href="https://www.ed.ac.uk" class="uoelogo" title="The University of Edinburgh Home" target="_blank" onclick="return warnNewTab()"></a>
         </div>
         <div id="collection-search">
             <form action="./redirect/" method="post">
                 <fieldset class="search">
                     <input type="text" name="q" value="<?php if (isset($searchbox_query)) echo urldecode($searchbox_query); ?>" id="q" />
                     <input type="submit" name="submit_search" class="btn" value="Search" id="submit_search" />
-                    <a href="./advanced" class="advanced">Advanced search</a>
+                    <div style="text-align:center;"><a href="./advanced" class="advanced">Advanced<br>search</a></div>
                 </fieldset>
             </form>
         </div>

--- a/theme/openbooks/views/index.php
+++ b/theme/openbooks/views/index.php
@@ -6,6 +6,6 @@
         <img src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/images/rhino.jpg"/>
     </div>
     <p>
-        The images that have been created by the University's Cultural Heritage Digitisation Service are freely accessible to all, and most of the material is supplied under a <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">Creative Commons CC BY License</a> (<a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">http://creativecommons.org/licenses/by/4.0/</a>), meaning you can share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Specific licence information is available on each item’s coversheet.
+        The images that have been created by the University's Cultural Heritage Digitisation Service are freely accessible to all, and most of the material is supplied under a <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank" onclick="return warnNewTab()">Creative Commons CC BY License</a> (<a href="http://creativecommons.org/licenses/by/4.0/" target="_blank" onclick="return warnNewTab()">http://creativecommons.org/licenses/by/4.0/</a>), meaning you can share and adapt for any purpose as long as attribution is given to the University of Edinburgh. Specific licence information is available on each item’s coversheet.
     </p>
 </div>

--- a/theme/openbooks/views/record.php
+++ b/theme/openbooks/views/record.php
@@ -111,10 +111,10 @@ if(isset($solr[$type_field])) {
                 if ($primopos !== false)
                 {
 
-                    echo '<a href="'.$uri.'" title="Link to Library catalogue entry" target="_blank">Library Catalogue Entry</a>';
+                    echo '<a href="'.$uri.'" title="Link to Library catalogue entry" target="_blank" onclick="return warnNewTab()">Library Catalogue Entry</a>';
                 }
                 else{
-                    echo '<a href="'.$uri.'" title="Link to '.$uri.'" target="_blank">'.$uri.'</a>';
+                    echo '<a href="'.$uri.'" title="Link to '.$uri.'" target="_blank" onclick="return warnNewTab()">'.$uri.'</a>';
                 }
                 if($index < sizeof($solr[$uri_field]) - 1) {
                     echo '<br />';
@@ -253,7 +253,7 @@ if(isset($solr[$bitstream_field]) && $link_bitstream) {
             <br>
             <iframe src="<?php echo base_url(); ?>theme/<?php echo $this->config->item('skylight_theme'); ?>/addons/PDF_Viewer/pdf_reader.php?url=<?php echo base_url() . $b_uri ?>" title="PDF Viewer" width="700" height="900"></iframe>
             <br>
-            Click <?php echo '<a href ="'.$bitstreamLink.'" target="_blank">'.$b_filename.'</a>' ?> to download.
+            Click <?php echo '<a href ="'.$bitstreamLink.'" target="_blank" onclick="return warnNewTab()">'.$b_filename.'</a>' ?> to download.
             (<span class="bitstream_size"><?php echo getBitstreamSize($bitstream); ?></span>)<br><br>
 
             <?php

--- a/theme/openbooks/views/recordwait.php
+++ b/theme/openbooks/views/recordwait.php
@@ -84,10 +84,10 @@ if(isset($solr[$type_field])) {
                 if ($primopos !== false)
                 {
 
-                    echo '<a href="'.$uri.'" title="Link to Library catalogue entry" target="_blank">Library Catalogue Entry</a>';
+                    echo '<a href="'.$uri.'" title="Link to Library catalogue entry" target="_blank" onclick="return warnNewTab()">Library Catalogue Entry</a>';
                 }
                 else{
-                    echo '<a href="'.$uri.'" title="Link to '.$uri.'" target="_blank">'.$uri.'</a>';
+                    echo '<a href="'.$uri.'" title="Link to '.$uri.'" target="_blank" onclick="return warnNewTab()">'.$uri.'</a>';
                 }
                 if($index < sizeof($solr[$uri_field]) - 1) {
                     echo '<br />';


### PR DESCRIPTION
# Guardbook changes
- All colour contrast issues have been resolved to meet WCAG 2.2 AA standards.
   - [1.4.3 - Contrast (Minimum)](https://www.w3.org/TR/WCAG21/#contrast-minimum)
- Increased font size to at least 12pt
- Added a popup to notify users that a new tab is about to be opened after clicking on a link.
   - [3.2.2 On input](https://www.w3.org/TR/WCAG21/#on-input)
- Added a skip to main content button on each page.
   - [2.4.1 Bypass Blocks](https://www.w3.org/TR/WCAG21/#bypass-blocks)
- Ensured that all links were underlined.

# Openbooks accessibility fixes:
- All colour contrast issues have been resolved to meet WCAG 2.2 AA standards. (08/08/2024)
   - [1.4.3 - Contrast (Minimum)](https://www.w3.org/TR/WCAG21/#contrast-minimum)
- Increased font size to at least 12pt (08/08/2024)
- Added a popup to notify users that a new tab is about to be opened after clicking on a link. (08/08/2024)
   - [3.2.2 On input](https://www.w3.org/TR/WCAG21/#on-input)
- Added a skip to main content button on each page. (08/08/2024)
   - 2.[4.1 Bypass Blocks](https://www.w3.org/TR/WCAG21/#bypass-blocks)
- Removed the transparency of the text over the image. (08/08/2024)
   - [1.4.5 Images of Text](https://www.w3.org/TR/WCAG22/#images-of-text)

# Other
- Fixed broken takedown links for EERC
 and main collections site.
- Fixed all broken links on guardbook.