### PR TITLE
Accessibility fixes for SOPA and accesibility statement updates

### DIFF
--- a/static/art/accessibility.php
+++ b/static/art/accessibility.php
@@ -1,200 +1,481 @@
-<div class="container">
-    <div class="content byEditor">
-        <h1>Accessibility Statement for the <a href="https://collections.ed.ac.uk/art">Art Collection website</a></h1>
-        <p><strong>Website accessibility statement inline with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</strong></p>
-        <p>This accessibility statement applies to  <a href="https://collections.ed.ac.uk/art">https://collections.ed.ac.uk/art</a></p>
+<!DOCTYPE html>
+<html lang="en">
 
-        <p>This website is run by the Library and University Collections Directorate which is part of Information Services Group at the University of Edinburgh. We want as many people as possible to be able to use this website. For example, that means you should be able to:</p>
-        <ul>
-            <li>using your browser settings, change colours, contrast levels and fonts</li>
-            <li>zoom in up to 400% without the text spilling off the screen</li>
-            <li>navigate most of the website using just a keyboard</li>
-            <li>navigate most of the website using speech recognition software</li>
-            <li>listen to most of the website using a screen reader (including the most recent versions of Job Access with Speech (JAWS), NonVisual Desktop Access (NVDA) and VoiceOver);</li>
-            <li>experience no time limits when using the site, and not encounter any flashing, scrolling or moving text.</li>
-        </ul>
-        <p>We&rsquo;ve also made the website text as simple as possible to understand.</p>
+<!-- Search for the double curly bracket chars to navigate to areas to change in this template e.g. Ctrl+F "{{" -->
 
-        <h2>Customising the website</h2>
-        <p>AbilityNet has advice on making your device easier to use if you have a disability. This is an external site with suggestions to make your computer more accessible:</p>
-        <p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet - My computer my way</a></p>
-        <p>With a few simple steps you can customise the appearance of our website using your browser settings to make it easier to read and navigate:</p>
-        <p><a href="https://www.ed.ac.uk/about/website/accessibility/customising-site">Additional information on how to customise our website appearance</a></p>
-        <p>If you are a member of University staff or a student, you can use the free SensusAccess accessible document conversion service:</p>
-        <p><a href="https://www.ed.ac.uk/student-disability-service/staff/supporting-students/accessible-technology">Information on SensusAccess</a></p>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<title>Accessibility Statement</title>
+    <style type="text/css">
+		@page { size: 21cm 29.7cm; margin: 2.54cm }
+		body, p { font-family: Arial, sans-serif; font-size: 12pt; line-height: 1.5; text-align: left; margin-bottom: 0.25cm; direction: ltr; }
+		h1, h2, h3 { color: #2f5496; text-align: left; margin-bottom: 0.5cm; direction: ltr; page-break-after: avoid }
+		h1 { font-size: 24pt; }
+		h2 { font-size: 20pt; }
+		h3 { font-size: 16pt; }
+		a:link, a:visited { color: #0563c1; text-decoration: underline }
+        body > *:not(#container), #container > *:not(#main), #main > *:not(div.col-main), div.col-main > footer{ display: none; }
+        .col-main {width:95%; margin:auto; padding:1em;}
+        ul {margin-bottom: 0; padding-bottom: 0; font-family: Arial, sans-serif;}
+	</style>
 
-        <h2>How accessible this website is</h2>
-        <p>We know some parts of this website are not fully accessible:</p>
-        <ul>
-            <li>not all colour contrasts meet the recommended Web Content Accessibility Guidelines 2.1 AA standard;</li>
-            <li>some body text is smaller than 12 point;</li>
-            <li>some images are oversized or blurry;</li>
-            <li>some links open in new windows or tabs without warning;</li>
-            <li>some content cannot be navigated to via keyboard;</li>
-            <li>there are instances of non-text content not containing alternative text;</li>
-            <li>there are instances of overlapping text when scaling the page or viewing in portrait mode via mobile;</li>
-            <li>the image carousel on the homepage does not have control buttons to pause or stop and the 'previous' and 'next' arrows are difficult to see;</li>
-            <li>most older PDF documents are not fully accessible to screen reader software;</li>
-            <li>there is no skip to main content function;</li>
-            <li>it can sometimes be hard to tell where you have navigated to using a keyboard;</li>
-            <li>some content is inaccessible using speech recognition software, including the image carousel buttons and collection record image zoom icons.</li>
-        </ul>
-
-        <h2>Feedback and contact information</h2>
-        <p>If you need information on this website in a different format, including accessible PDF, large print, audio recording or braille:</p>
-        <ul>
-            <li>Email: <a href="mailto:HeritageCollections@ed.ac.uk">HeritageCollections@ed.ac.uk</a></li>
-            <li>Telephone: +44 (0)131 650 8379</li>
-            <li>British Sign Language (BSL) users can contact us via Contact Scotland BSL, the on-line BSL interpreting service: <a href="https://contactscotland-bsl.org/">Contact Scotland BSL</a></li>
-        </ul>
-
-        <h2>Reporting accessibility problems with this website</h2>
-        <p>We are always looking to improve the accessibility of this website. If you find any problems not listed on this page, or think we're not meeting accessibility requirements, please contact:</p>
-        <ul>
-            <li>Email: <a href="mailto:HeritageCollections@ed.ac.uk">HeritageCollections@ed.ac.uk</a></li>
-            <li>Telephone: +44 (0)131 650 8379</li>
-            <li>British Sign Language (BSL) users can contact us via Contact Scotland BSL, the on-line BSL interpreting service: <a href="https://contactscotland-bsl.org/">Contact Scotland BSL</a></li>
-        </ul>
-        <p>We will consider your request and get back to you in 5 working days.</p>
-
-        <h2>Enforcement procedure</h2>
-        <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint please contact the Equality Advisory and Support Service (EASS) directly:</p>
-        <p><a href="https://www.equalityadvisoryservice.com/">Contact details for the Equality Advisory and Support Service (EASS)</a></p>
-        <p>The government has produced information on how to report accessibility issues:</p>
-        <p><a href="https://www.gov.uk/reporting-accessibility-problem-public-sector-website">Reporting an accessibility problem on a public sector website</a></p>
-
-        <h2>Contacting us by phone using British Sign Language</h2>
-        <p>British Sign Language service Contact Scotland BSL runs a service for British Sign Language users and all of Scotland’s public bodies using video relay. This enables sign language users to contact public bodies and vice versa. The service operates 24 hours a day, 7 days a week.</p>
-        <p><a href="https://contactscotland-bsl.org/">Contact Scotland BSL service details</a></p>
-
-        <h2>Technical information about this website&rsquo;s accessibility</h2>
-        <p>The University of Edinburgh is committed to making its websites and applications accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-        <p>This website is partially compliant with the Web Content Accessibility Guidelines (WCAG) 2.1 AA standard, due to the non-compliances listed below.</p>
-        <p>The full guidelines are available at:</p>
-        <p>&nbsp;<a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a></p>
-        <h3>Non accessible content</h3>
-        <p>The content listed below is non-accessible for the following reasons.</p>
-        <h3>Noncompliance with the accessibility regulations</h3>
-        <p>The following items to not comply with the WCAG 2.1 AA success criteria:</p>
-        <ul>
-            <li>Not all non-text content presented to users has alternative text
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#non-text-content">1.1.1 - Non-text Content</a></li>
-                </ul>
-            </li>
-            <li>Information, structure and relationships conveyed through presentation cannot always be programmatically determined. This includes a missing < h1 > on the homepage.
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">1.3.1 - Info and Relationships</a></li>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#headings-and-labels">2.4.6 - Headings and Labels</a></li>
-                </ul>
-            </li>
-            <li>On mobile devices it is not possible to view the information in portrait as the text becomes jumbled on the search page. Content will only display correctly  in a single page orientation
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 - Orientation</a></li>
-                </ul>
-            </li>
-            <li>There may not be sufficient colour contrast between font and background colours, especially where the text size is small
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></li>
-                </ul>
-            </li>
-            <li>Site is not fully compatible with browser customisation meaning that users do not have full control and functionality when customising the site (WCAG 2.1 AAA)
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#visual-presentation">1.4.8 - Visual Presentation (AAA) </a></li>
-                </ul>
-            </li>
-            <li>Visual information to identify user interface components, such as keyboard focus, do not always have a sufficient contrast ratio
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#focus-visible">2.4.7 - Focus Visible</a></li>
-                </ul>
-            </li>
-            <li>It is not possible to use a keyboard to access all the content
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#keyboard">2.1.1 Keyboard</a></li>
-                </ul>
-            </li>
-            <li>It is not always possible to bypass blocks of content that are repeated on multiple Web pages
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#bypass-blocks">2.4.1 Bypass Blocks</a></li>
-                </ul>
-            </li>
-            <li>Some of our page titles do not fully describe the page content whereas others are missing altogether
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#page-titled">2.4.2 - Page Titled</a></li>
-                </ul>
-            </li>
-            <li>Information, structure and relationships conveyed through presentation cannot always be programmatically determined. This includes missing heading labels
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#headings-and-labels">2.4.6 - Headings and Labels</a></li>
-                </ul>
-            </li>
-            <li>Some links open in a new browser window without warning
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#change-on-request">3.2.5 Change on Request</a></li>
-                </ul>
-            </li>
-            <li>There are issues with compatibility with text to speech software and screen readers
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#parsing">4.1.1 Parsing</a></li>
-                </ul>
-            </li>
-            <li>Screen readers are not able to identify some parts of the page
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#name-role-valuet">4.1.2 - Name, Role, Value</a></li>
-                </ul>
-            </li>
-            <li>Not all our PDF's and Word documents meet accessibility standards.
-                <ul>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#non-text-content">1.1.1 Non-text Content</a></li>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#meaningful-sequence">1.3.2 - Meaningful Sequence</a></li>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#images-of-text">1.4.5 - Images of text</a></li>
-                    <li><a href="https://www.w3.org/TR/WCAG21/#multiple-ways">2.4.5 - Multiple Ways</a></li>
-                </ul>
-            </li>
-        </ul>
-        <p>At this time, we believe all items are within our control. Unless specified otherwise, a complete solution, or significant improvement, will be in place for those items within our control by March 2024.</p>
-        <h3>Disproportionate burden</h3>
-        <p>We are not currently claiming that any accessibility problems would be a disproportionate burden to fix.</p>
-        <h3>Content that's not within the scope of the accessibility regulations</h3>
-        <p>At this stage we do not believe anything is out of scope of the regulations</p>
-
-        <h2>What we're doing to improve accessibility</h2>
-        <p>At this time, we believe all items are within our control. We will continue to address the accessibility issues highlighted to deliver a solution or suitable workaround. We are looking to move this site to a new content management system within the next 12 months and will be working to ensure this resolves the accessibility issues. Unless specified otherwise, a complete solution or significant improvement will be in place for those items within our control by March 2024.</p>
-        <p>While we are in the process of resolving these accessibility issues, or where we are unable, we will ensure reasonable adjustments are in place to make sure no user is disadvantaged. As changes are made, we will continue to review accessibility and retest the accessibility of this website.</p>
-
-        <h2>Preparation of this accessibility statement</h3>
-        <p><strong>This statement was first prepared on 15th September 2021. It was last reviewed on 01 March 2023.</strong></p>
-        <p>This website was first tested by the Digital Library & Development team on 15th September 2021 and last reviewed on 01 March 2023. The testing was initially carried out by The University of Edinburgh Library and University Collections Digital Library Development team using the automated <a href="https://littleforest.co.uk/">Little Forest</a> testing tool.
-        <p>This website was last manually tested by the Digital Library team, Library and University Collections, University of Edinburgh in <strong>February 2023</strong>. This was primarily using Mozilla Firefox (91.7.1esr), Microsoft Edge (99.0.1150.55) and Google Chrome (99.0.4844.84), browsers for comparative purposes.</p>
-        <p>Recent world-wide usage levels survey for different screen readers and browsers shows that Chrome, Mozilla Firefox and Microsoft Edge are increasing in popularity and Google Chrome is now the favoured browser for screen readers:</p>
-        <p><a href="https://webaim.org/projects/screenreadersurvey9/">WebAIM: Screen Reader User Survey</a></p>
-        <p>The aforementioned three browsers have been used in certain questions for reasons of breadth and variety.</p>
-        <p>We ran automated testing using <a href="https://littleforest.co.uk/">Little Forest</a> then manual testing that included:</p>
-
-        <h3>Manual Testing</h3>
-        <p>we tested:</p>
-        <ul>
-            <li>Spell check functionality;</li>
-            <li>Scaling using different resolutions and reflow;</li>
-            <li>Options to customise the interface (magnification, font, background colour, etc);</li>
-            <li>Keyboard navigation and keyboard traps;</li>
-            <li>Data validation;</li>
-            <li>Warning of links opening in a new tab or window;</li>
-            <li>Information conveyed in colour or sound only;</li>
-            <li>Flashing, moving or scrolling text;</li>
-            <li>Operability if JavaScript is disabled;</li>
-            <li>Use with screen reading software (for example, JAWS);</li>
-            <li>Assistive software (TextHelp Read and Write, Windows Magnifier, ZoomText, Dragon NaturallySpeaking, TalkBack and VoiceOver);</li>
-            <li>Tooltips and text alternatives for any non-text content;</li>
-            <li>Time limits;</li>
-            <li>Compatibility with mobile accessibility functionality (Android and iOS).</li>
-        </ul>
-
-        <h2>Change Log</h2>
-        <p>Since our first evaluation and statement, which was based on automated testing, we have undertaken extensive manual testing. This includes utilising a range of assistive technology to ensure we have a clear picture of the accessibility issues and how best to resolve them.</p>
-    </div>
-</div>
+</head>
+<body lang="en-GB" link="#0563c1" vlink="#954f72" dir="ltr">
 
 
+<h1>Accessibility
+statement for the <a href="https://collections.ed.ac.uk/art/">University of Edinburgh Art Collection Website</a></h1>
+</p>
+<p>
+
+</p>
+<p>Website accessibility statement inline with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</p>
+<p>
+
+</p>
+<p>This accessibility statement applies to:</p>
+<p><a href="https://collections.ed.ac.uk/art/">https://collections.ed.ac.uk/art/</a>
+</p>
+
+<p>
+</p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect and will need to be edited}} -->
+
+<p>This website is run by Library and University Collections, Information Services Group at the University of Edinburgh. We want as many people as possible to be
+able to use this application. For example, that means you should be
+able to:</p>
+<p>
+
+<!-- {{This sections varies. Check the items listed below match with the approved Statement - add/delete items as necessary }} -->
+
+</p>
+<ul>
+<li>Using browser settings, customise most of the colours.</li>
+<li>Zoom in up to 400% (without reflow).</li>
+<li>Navigate the website using just a keyboard.</li>
+<li>Experience no time limits when using the site.</li>
+<li>Not encounter any flashing, scrolling or moving text.</li>
+</ul>
+<p>
+
+</p>
+<p>We’ve also made the website text as simple as possible to understand.</p>
+<p>
+
+</p>
+<h2>Customising the website</h2>
+<p>
+AbilityNet
+has advice on making your device easier to use if you have a
+disability. This is an external site with suggestions to make your
+computer more accessible:</p>
+<p>
+
+</p>
+<p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet
+- My Computer My Way</a></p>
+<p>
+
+</p>
+<p>With
+a few simple steps you can customise the appearance of our website
+using your browser settings to make it easier to read and navigate:</p>
+<p>
+
+</p>
+<p><a href="https://www.ed.ac.uk/about/website/accessibility/customising-site" target="Customising our site">Additional
+information on how to customise our website appearance</a></p>
+<p>
+
+</p>
+<p>If
+you are a member of University staff or a student, you can use the free SensusAccess accessible document conversion service:</p>
+<p>
+
+</p>
+<p><a href="https://www.ed.ac.uk/student-disability-service/staff/supporting-students/accessible-technology">Information
+on SensusAccess</a></p>
+<p>
+
+</p>
+<h2>How accessible this website is</h2>
+<p>
+
+</p>
+<p>We know some parts of this website are not fully accessible:</p>
+<p>
+
+</p>
+
+<!-- {{This section varies according to the site. Edit as appropriate}} -->
+
+<ul>
+<li>Not all colour contrasts meet the minimum standards.</li>
+<li>Content starts to overlap and spill when font size is increased using the browser settings.</li>
+<li>Reflow is not enabled to 400% on some pages.</li>
+<li>Some non-text content does not have alternative text.</li>
+<li>All links do not have meaningful hypertext.</li>
+<li>Some hyperlinks are conveyed in colour only and are not underlined.</li>
+<li>Some links open in a new tab/window without warning.</li>
+<li>Some error messages do not give a clear description of how to fix an error and the location of the error.</li>
+<li>Assistive software such as voice recognition and screen readers are not fully compatible with the website.</li> 
+<li>Tooltips do not appear when navigating with keyboard, mouse hover or assistive software and some appear as duplicates.</li>
+<li>There are PDF documents that are not fully accessible.</li>
+<li>The site is not fully compatible with assistive software such as screen readers or voice recognition software.</li>
+</ul>
+<p>
+
+</p>
+<h2>Feedback and contact information</h2>
+<p>
+
+</p>
+<p>If
+you need information on this website in a different format, including
+accessible PDF, large print, audio recording or braille:
+</p>
+
+<!-- {{You may need to change the contact details if the site is not within the control of L&UC}} -->
 
 
+<ul>
+	<li>Email: <a href="mailto:Information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></li>
+	<li>Telephone: +44 (0)131 651 5151</li>
+	<li>Use the <a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline online contact form</a></li>
+	<li>British Sign Language (BSL) users can contact us via <a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL</a>, the on-line BSL interpreting service
+</ul>
+
+<p>We’ll consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
+<h2>Reporting accessibility problems with this website</h2>
+<p>
+We are always looking to improve the accessibility of this website. If
+you find any problems not listed on this page, or think we’re not
+meeting accessibility requirements, please contact:&nbsp;
+
+
+</p>
+
+<!-- {{You may need to change the contact details if the site is not within the control of L&UC}} -->
+
+<ul>
+	<li>Email: <a href="mailto:Information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></li>
+	<li>Telephone: +44 (0)131 651 5151</li>
+	<li>Use the <a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline online contact form</a></li>
+	<li>British Sign Language (BSL) users can contact us via <a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL</a>, the on-line BSL interpreting service.
+</ul>
+<p>We
+will consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
+<h2>Enforcement procedure</h2>
+<p>
+The
+Equality and Human Rights Commission (EHRC) is responsible for
+enforcing the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018 (the ‘accessibility
+regulations’). If you’re not happy with how we respond to your
+complaint please contact the Equality Advisory and Support Service
+(EASS) directly:</p>
+<p>
+
+</p>
+<p><a href="https://www.equalityadvisoryservice.com/">Contact
+details for the Equality Advisory and Support Service (EASS)</a></p>
+<p>
+
+</p>
+<p>The
+government has produced information on how to report accessibility
+issues:</p>
+<p>
+
+</p>
+<p><a href="https://www.gov.uk/reporting-accessibility-problem-public-sector-website">Reporting
+an accessibility problem on a public sector website</a></p>
+<p>
+
+</p>
+<h2>Contacting us by phone using British Sign Language</h2>
+<p>
+British
+Sign Language service</p>
+<p>Contact
+Scotland BSL runs a service for British Sign Language users and all
+of Scotland’s public bodies using video relay. This enables sign
+language users to contact public bodies and vice versa. The service
+operates from 8.00am to 12.00am, 7 days a week.</p>
+<p><a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL service details.</a></p>
+<p>
+
+
+</p>
+<h2>Technical information about this website’s accessibility</h2>
+<p>The
+University of Edinburgh is committed to making its websites and
+applications accessible, in accordance with the Public Sector Bodies
+(Websites and Mobile Applications) (No. 2) Accessibility Regulations
+2018.</p>
+<p>
+
+</p>
+<h2>Compliance Status</h2>
+<p>This website is partially compliant with the Web Content Accessibility Guidelines (WCAG) 2.2 AA standard, due to the non-compliances listed below.</p>
+<p>
+
+</p>
+<p>The
+full guidelines are available at:</p>
+<p>
+
+</p>
+<p><a href="https://www.w3.org/TR/WCAG22/">Web
+Content Accessibility Guidelines (WCAG) 2.2 AA standard</a></p>
+<p>
+
+</p>
+<h2>Non accessible content</h2>
+<p>
+
+</p>
+<p>The
+content listed below is non-accessible for the following reasons.</p>
+<p></p>
+<h3>Noncompliance with the accessibility regulations
+
+
+</h3>
+<p>The
+following items do not comply with the WCAG 2.2 AA success criteria:</p>
+<p>
+
+</p>
+<p>
+
+</p>
+
+
+<!-- {{Add sections which apply to this statement}} -->
+<!-- {{Maintain the formatting of the items, as shown below in the examples below}} -->
+
+
+	<ul><li>Some non-text content does not have appropriate alternative text and some ARIA progress bar nodes do not have an accessible name<p></li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1 - Non Text Content</a></p>
+
+
+    <ul><li>Not all information, structure, and relationships conveyed through presentation are programmatically determined e.g., there are unordered lists</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1 - Info and Relationships</a></p>
+
+
+	<ul><li>Some hyperlinks are conveyed with colour only</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#use-of-color">1.4.1 - Use of Color</a></p>
+
+
+	<ul><li>There may not be sufficient colour contrast between font and background colours, especially where the text size is small</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></p>
+
+
+	<ul><li>Reflow is not enabled to 400% on some pages</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#reflow">1.4.10 - Reflow</a></p>
+
+
+	<ul><li>When attempting to customise the site, there were issues with rendering on some text elements, whereby some text elements were positioned over images, became cut off and could not be read in full</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#text-spacing">1.4.12 - Text Spacing</a></p>
+
+
+	<ul><li>Not all tooltips are accessible when using keyboard or assistive technology</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus">1.4.13 - Content on Hover or Focus</a></p>
+
+
+	<ul><li>Some links do not contain meaningful hypertext to inform the user of their target location</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#link-purpose-in-context">2.4.4 - Link Purpose (in Context)</a></p>
+
+
+	<ul><li>Some links open in a new tab or open pop up without warning</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#on-input">3.2.2 - On Input</a></p>
+
+
+	<ul><li>Some error messages do not give a clear description of how to fix an error and the location of the error</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#error-identification">3.3.1 - Error Identification</a></p>
+
+
+	<ul><li>The website is not fully compatible with assistive software as not all select elements have an accessible name and only use supported ARIA attributes.</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#name-role-value">4.1.2 - Name-Role-Value</a></p>
+
+
+<ul><li>There are PDFs which are not fully accessible.</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#keyboard">2.1.1 - Keyboard</a></p>
+	<p><a href="https://www.w3.org/TR/WCAG22/#name-role-value">4.1.2 - Name-Role-Value</a></p>
+
+
+
+<p>We
+aim to improve our websites accessibility on a regular and continuous
+basis. See the section below ('What we're doing to improve
+accessibility') on how we are improving our site accessibility. 
+</p>
+<p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect}} -->
+<!-- {{Add DATE_FOR_IMPROVEMENTS = Date Statement was approved + 11 months}} -->
+</p>
+<p>We
+are working towards solving these problems and expect significant
+improvements by July 2026. The site is fully within our control.</p>
+<p>
+
+<!-- {{The statement may make claims of disproportionate burden, double-check that it matches below}} -->
+
+</p>
+<h3>Disproportionate burden</h3>
+<p>
+We
+are not currently claiming that any accessibility problems would be a
+disproportionate burden to fix.</p>
+<p>
+
+<!-- {{The statement may make claims of not within scope of regulations, double-check that it matches below}} -->
+
+</p>
+<h3>Content that’s not within the scope of the accessibility regulations</h3>
+<p>
+
+</p>
+<p>At
+this time we believe no content is outwith the scope of the accessibility regulations.</p>
+<p>
+
+</p>
+<h2>What we’re doing to improve accessibility</h2>
+<p>
+
+</p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect}} -->
+<!-- {{Add DATE_FOR_IMPROVEMENTS = Date Statement was approved + 11 months}} -->
+
+<p>We
+will continue to address and make significant improvements to the
+accessibility issues highlighted. Unless specified otherwise, a
+complete solution or significant improvement will be in place by July 2026. At this time we believe the site is fully under our control.
+<p>
+
+</p>
+<p>While
+we are in the process of resolving these accessibility issues we will
+ensure reasonable adjustments are in place to make sure no user is
+disadvantaged. As changes are made, we will continue to review
+accessibility and retest the accessibility of this website.</p>
+<p>
+
+</p>
+<p>
+
+<!-- {{Add the required dates to this section}} -->
+<!-- {{FIRST_STATEMENT_DATE = the date of the FIRST version of this statement - check the currently published version of the site for the date to use}} -->
+<!-- {{LAST_REVIEW_DATE = the date this version of the statement was approved by Viki's team }} -->
+<!-- {{TESTING_DATE = the date this version of the statement was tested.  If it was tested over multiple days then use the last day}} -->
+
+</p>
+<h2>Preparation of this accessibility statement</h2>
+<p><b>This statement was prepared on 15th September 2021. It was last reviewed on 22nd July 2025.</b></p> 
+
+<p><b>The website was last tested on 19th July 2025. The
+testing was carried out by Library
+and University Collections, Information Services Group at the University of Edinburgh</b> using
+both automated and manual methods. The site was tested on a PC,
+primarily using Microsoft Edge alongside Mozilla Firefox and Google
+Chrome.</p>
+<p>
+
+</p>
+<p>Recent
+world-wide usage levels survey for different screen readers and
+browsers shows that Chrome, Mozilla Firefox and Microsoft Edge are
+increasing in popularity and Google Chrome is now the favoured
+browser for screen readers:</p>
+<p>
+
+</p>
+<p><a href="https://webaim.org/projects/screenreadersurvey9/">WebAIM:
+Screen Reader User Survey</a></p>
+<p>
+
+</p>
+<p>The
+aforementioned three browsers have been used in certain questions for
+reasons of breadth and variety.</p>
+<p>
+
+</p>
+<p>We
+ran automated testing using <a href="https://www.deque.com/axe/devtools/chrome-browser-extension/">AXE Devtools</a> and
+then manual testing that included:</p>
+
+<!-- {{Check the items on the list below match with the approved statement - add/delete as appropriate}} -->
+
+<ul>
+	<li>Spell
+	check functionality;</li>
+	<li>Scaling
+	using different resolutions and reflow;</li>
+	<li>Options
+	to customise the interface (magnification, font, background colour,
+	etc);</li>
+	<li>Keyboard
+	navigation and keyboard traps;</li>
+	<li>Data
+	validation;</li>
+	<li>Warning
+	of links opening in new tab or window;</li>
+	<li>Information
+	conveyed in the colour or sound only;</li>
+	<li>Flashing,
+	moving or scrolling text;</li>
+	<li>Operability if JavaScript is disabled;</li>
+	<li>Use
+	with screen reading software (for example JAWS);</li>
+	<li>Assistive
+	software (TextHelp Read and Write, Windows Magnifier, ZoomText,
+	Dragon Naturally Speaking, TalkBack and VoiceOver);</li>
+	<li>Tooltips
+	and text alternatives for any non-text content;</li>
+	<li>Time
+	limits;</li>
+	<li>Compatibility
+	with mobile accessibility functionality (Android and iOS);</li>
+	<li>Any drag functionality and alternatives;</li>
+	<li>Consistent help function;</li>
+	<li>No need to re-enter data already submitted;</li>
+	<li>Any cognitive tests.</li>
+</ul>
+
+<!-- {{Delete the entire Change Log section if this is the first manual test - i.e. no fixes have been implemented}} -->
+<!-- {{The fixes should be grouped by date.  They should contain a description of the fix and the WCAG element referred to - see example below. Entries should follow the same format as below}} -->
+
+<h2>Change Log</h2>
+<p>Since our first evaluation and statement, which was based on automated testing, we have undertaken extensive manual testing. This includes utilising a range of assistive technology to ensure we have a clear picture of the accessibility issues and how best to resolve them.</p>
+	<ul><li>Some colour contrast issues have been resolved to meet WCAG 2.2 AA standards. (12/08/2024).</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></p>
+
+
+	<ul><li>A skip to main content button has been added on each page. (12/08/2024).</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG21/#bypass-blocks">2.4.1 - Bypass Blocks</a></p>
+
+
+	<ul><li>The results, sort and pagination in the ‘Search’ page now warps instead of overlapping. (12/08/2024).</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#text-spacing">1.4.12 - Text Spacing</a></p>
+
+
+	<ul><li>Added alt text to some images. (12/08/2024).</li></ul>
+	<p><a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1 - Non-text Content</a></p>
+
+</body>
+</html>

--- a/static/iog/accessibility.php
+++ b/static/iog/accessibility.php
@@ -1,988 +1,468 @@
-<html>
-<h1>Accessibility Statement for <a href="http://www.scottishgovernmentyearbooks.ed.ac.uk/">Scottish Government Yearbooks</a></h1>
-<p>Website accessibility statement in line with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</p>
-<p><a href="http://www.scottishgovernmentyearbooks.ed.ac.uk/">Scottish Government Yearbooks</a> - <a href="http://www.scottishgovernmentyearbooks.ed.ac.uk/">http://www.scottishgovernmentyearbooks.ed.ac.uk/</a> is a website hosted by the University of Edinburgh Library on behalf of the University of Edinburgh. Scottish Government Yearbooks is published by the University of Edinburgh's 'Unit for the Study of Government in Scotland' between 1976 and 1992.</p>
-<p>We want as many people as possible to be able to use our website. For example, this means you should be able to:</p>
+<!DOCTYPE html>
+<html lang="en">
+
+<!-- Search for the double curly bracket chars to navigate to areas to change in this template e.g. Ctrl+F "{{" -->
+
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<title>Accessibility Statement</title>
+    <style type="text/css">
+		@page { margin: 1em; }
+		body, p { font-family: Arial, sans-serif; font-size: 12pt; line-height: 1.5; text-align: left; margin-bottom: 0.25cm; direction: ltr; background: transparent }
+		h1, h2, h3 { color: #2f5496; text-align: left; margin-bottom: 0.5cm; direction: ltr; background: transparent; page-break-after: avoid }
+		h1 { font-size: 24pt; }
+		h2 { font-size: 20pt; }
+		h3 { font-size: 16pt; }
+		a:link, a:visited { color: #0563c1; text-decoration: underline }
+        body > *:not(#container), #container > *:not(#main), #main > *:not(div.col-main), div.col-main > footer{ display: none; }
+        .col-main {width: 100%; margin:0;}
+	</style>
+
+</head>
+<body lang="en-GB" link="#0563c1" vlink="#954f72" dir="ltr">
+
+
+<h1>Accessibility
+Statement for <a href="http://www.scottishgovernmentyearbooks.ed.ac.uk/">Scottish Government Yearbooks </a></h1>
+</p>
+<p>
+
+</p>
+<p>Website accessibility statement inline with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</p>
+<p>
+
+</p>
+<p>This accessibility statement applies to:</p>
+<p><a href="http://www.scottishgovernmentyearbooks.ed.ac.uk/">http://www.scottishgovernmentyearbooks.ed.ac.uk/</a>
+</p>
+
+<p>
+</p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect and will need to be edited}} -->
+
+<p>This website is run by the Library and University Collections Directorate, Information Services Group at the University of Edinburgh. We want as many people as possible to be
+able to use this application. For example, that means you should be
+able to:</p>
+<p>
+
+<!-- {{This sections varies. Check the items listed below match with the approved Statement - add/delete items as necessary }} -->
+
+</p>
 <ul>
-    <li>change colours, contrast levels and fonts.</li>
-    <li>experience no time limits to content</li>
-    <li>navigate most of the website using just a keyboard</li>
-    <li>magnify up to 200%</li>
+<li>Use browser settings to change colours, contrast levels and fonts</li>
+<li>Navigate most of the website using just a keyboard</li>
+<li>Listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+<li>Navigate most of the site using voice recognition software (e.g. Dragon NaturallySpeaking)</li>
+<li>Experience no time limits when using the website</li>
+<li>Use the site without encountering any scrolling, flashing or moving text</li>
 </ul>
-<p>We&rsquo;ve also made the website text as simple as possible to understand.</p>
+<p>
+
+</p>
+<p>We’ve also made the website text as simple as possible to understand. However, some of our content is technical, and we use technical terms where there is no easier wording we could use without changing what the text means.</p>
+<p>
+
+</p>
 <h2>Customising the website</h2>
-<p>AbilityNet has advice on making your device easier to use if you have a disability.</p>
-<p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet - My computer my way</a></p>
-<p>With a few simple steps you can customise the appearance of our website to make it easier to read and navigate.</p>
-<p><a href="https://www.ed.ac.uk/about/website/accessibility/customising-site">Additional information on how to customise our website appearance</a></p>
-<p>If you are a member of the University staff or a student you can use the free Sensus Access accessible document conversion service.</p>
-<p><a href="https://www.ed.ac.uk/student-disability-service/staff/supporting-students/accessible-technology">SenusAccess Information</a></p>
+<p>
+AbilityNet
+has advice on making your device easier to use if you have a
+disability. This is an external site with suggestions to make your
+computer more accessible:</p>
+<p>
+
+</p>
+<p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet
+- My Computer My Way</a></p>
+<p>
+
+</p>
+<p>With
+a few simple steps you can customise the appearance of our website
+using your browser settings to make it easier to read and navigate:</p>
+<p>
+
+</p>
+<p><a href="https://www.ed.ac.uk/about/website/accessibility/customising-site" target="Customising our site">Additional
+information on how to customise our website appearance</a></p>
+<p>
+
+</p>
+<p>If
+you are a member of University staff or a student, you can use the free SensusAccess accessible document conversion service:</p>
+<p>
+
+</p>
+<p><a href="https://www.ed.ac.uk/student-disability-service/staff/supporting-students/accessible-technology">Information
+on SensusAccess</a></p>
+<p>
+
+</p>
 <h2>How accessible this website is</h2>
+<p>
+
+</p>
 <p>We know some parts of this website are not fully accessible:</p>
+<p>
+
+</p>
+
+<!-- {{This section varies according to the site. Edit as appropriate}} -->
+
 <ul>
-    <li>You may not be able to fully navigate the pages using a screen reader e.g. a screen reader may not be able to determine what the content is and how it relates to other content</li>
-    <li>The colours on are pages may not meet current colour contrast recommendations</li>
-    <li>User interface elements may not be compatible with assistive technology</li>
-    <li>Not all our web pages have a title that clearly describes their purpose</li>
+<li>Screen reader compatibility on mobile devices is inconsistent in some areas</li>
+<li>Content overlaps when viewed in portrait or landscape on mobile devices</li>
+<li>Some links are not underlined and rely on colour alone</li>
+<li>There are a few instances of text presented as images</li>
+<li>Zooming on iOS causes overlapping text and layout issues</li>
+<li>Page layout does not reflow properly beyond 200% zoom</li>
+<li>The tabbing order in the navigation menu is not logical</li>
+<li>Some links are not clearly labelled or do not make their purpose clear</li>
+<li>Some links lead to broken or empty pages (e.g., the Institute of Governance logo)</li>
+<li>The search bar and dropdown on the ‘Advanced Search’ page are missing accessible names or labels</li>
+<li>Some content cannot be interpreted reliably by assistive technologies</li>
+<li>PDFs on the site are not fully accessible with screen readers or keyboard navigation</li>
 </ul>
-<h3>Feedback and contact information</h3>
-<p>If you need information on this website in a different format like accessible PDF, large print, audio recording or braille please contact the website team by contacting us:</p>
-<p>By using the IS Helpline online contact form</p>
-<p><a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline contact form</a></p>
-<p>Or phoning</p>
-<p>+44 (0)131 651 5151</p>
-<p>Or email</p>
-<p><a href="mailto:information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></p>
-<p>We&rsquo;ll consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
+<h2>Feedback and contact information</h2>
+<p>
+
+</p>
+<p>If
+you need information on this website in a different format, including
+accessible portable document format (PDF), large print, audio recording or braille:
+</p>
+
+<!-- {{You may need to change the contact details if the site is not within the control of L&UC}} -->
+
+
+<ul>
+	<li>Email: <a href="mailto:Information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></li>
+	<li>Telephone: +44 (0)131 651 5151</li>
+	<li>Use the <a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline online contact form</a></li>
+	<li>British Sign Language (BSL) users can contact us via <a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL</a>, the on-line BSL interpreting service.
+</ul>
+
+<p>We’ll consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
 <h2>Reporting accessibility problems with this website</h2>
-<p>We&rsquo;re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we&rsquo;re not meeting accessibility requirements please let us know by contacting:</p>
-<p>By using the IS Helpline online contact form</p>
-<p><a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline contact form</a></p>
-<p>Or phoning</p>
-<p>+44 (0)131 651 5151</p>
-<p>Or email</p>
-<p><a href="mailto:information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></p>
-<p>We&rsquo;ll consider your request and get back to you in 5 working&nbsp;days.</p>
-<h2>Enforcement procedure</h2>
-<p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the &lsquo;accessibility regulations&rsquo;). If you&rsquo;re not happy with how we respond to your complaint please contact the Equality Advisory and Support Service (EASS) directly.</p>
-<p><a href="https://www.equalityadvisoryservice.com/">Contact details for the Equality Advisory and Support Service (EASS)</a></p>
-<p>The government has produced information on how to report accessibility issues:</p>
-<p><a href="https://www.gov.uk/reporting-accessibility-problem-public-sector-website">Reporting an accessibility problem on a public sector website</a></p>
-<h2>Contacting us by phone using British Sign Language</h2>
-<h3>British Sign Language service</h3>
-<p>British Sign Language Scotland runs a service for British Sign Language users and all of Scotland&rsquo;s public bodies using video relay. This enables sign language users to contact public bodies and vice versa. The service operates from 8am to 12 midnight, 7 days a week.&nbsp;</p>
-<p><a href="https://contactscotland-bsl.org/">British Sign Language Scotland service details</a></p>
-<h2>Technical information about this website&rsquo;s accessibility</h2>
-<p>The University of Edinburgh is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-<h3>Compliance Status</h3>
-<p>This website is partially compliant with the Web Content Accessibility Guidelines 2.1 AA standard, due to the non-compliances listed below</p>
-<p>The full guidelines are available at</p>
-<p><a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a></p>
-<h3>Non accessible content</h3>
-<p>The content listed below is non-accessible for the following reasons.</p>
-<p>The following items to not comply with the WCAG 2.1 AA success criteria</p>
+<p>
+We are always looking to improve the accessibility of this website. If
+you find any problems not listed on this page, or think we’re not
+meeting accessibility requirements, please contact:&nbsp;
+
+
+</p>
+
+<!-- {{You may need to change the contact details if the site is not within the control of L&UC}} -->
+
 <ul>
-    <li>Information, structure, and relationships conveyed through presentation can be programmatically determined or are available in text.
-        <ul>
-            <li><a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">1.3.1 Info and Relationships</a></li>
-        </ul>
-    </li>
-    <li>There may not be sufficient colour contrast between font and background colours especially where the text size is very small.
-        <ul>
-            <li><a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast">1.4.3 -Contrast (Minimum)</a></li>
-        </ul>
-    </li>
-    <li>Web pages do not have titles that describe topic or purpose.
-        <ul>
-            <li><a href="https://www.w3.org/TR/WCAG21/#page-titled">2.4.2 Page Titled</a></li>
-        </ul>
-    </li>
-    <li>Some input elements do not have a name available to an accessibility API.
-        <ul>
-            <li><a href="https://www.w3.org/TR/WCAG21/#name-role-value">4.1.2 Name, Role, Value</a></li>
-        </ul>
-    </li>
+	<li>Email: <a href="mailto:Information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></li>
+	<li>Telephone: +44 (0)131 651 5151</li>
+	<li>Use the <a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline online contact form</a></li>
+	<li>British Sign Language (BSL) users can contact us via <a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL</a>, the on-line BSL interpreting service.
 </ul>
-<p>A complete solution or significant improvement will be in place by July 2022 where the issues are within our control.</p>
+<p>We'll consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
+<h2>Enforcement procedure</h2>
+<p>
+The
+Equality and Human Rights Commission (EHRC) is responsible for
+enforcing the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018 (the ‘accessibility
+regulations’). If you’re not happy with how we respond to your
+complaint please contact the Equality Advisory and Support Service
+(EASS) directly:</p>
+<p>
+
+</p>
+<p><a href="https://www.equalityadvisoryservice.com/">Contact
+details for the Equality Advisory and Support Service (EASS)</a></p>
+<p>
+
+</p>
+<p>The
+government has produced information on how to report accessibility
+issues:</p>
+<p>
+
+</p>
+<p><a href="https://www.gov.uk/reporting-accessibility-problem-public-sector-website">Reporting
+an accessibility problem on a public sector website</a></p>
+<p>
+
+</p>
+<h2>Contacting us by phone using British Sign Language</h2>
+<p>
+British
+Sign Language service</p>
+<p>Contact
+Scotland BSL runs a service for British Sign Language users and all
+of Scotland’s public bodies using video relay. This enables sign
+language users to contact public bodies and vice versa. The service
+operates from 8.00am to 12.00am, 7 days a week.</p>
+<p><a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL service details.</a></p>
+<p>
+
+
+</p>
+<h2>Technical information about this website’s accessibility</h2>
+<p>The
+University of Edinburgh is committed to making its websites and
+applications accessible, in accordance with the Public Sector Bodies
+(Websites and Mobile Applications) (No. 2) Accessibility Regulations
+2018.</p>
+<p>
+
+</p>
+<h2>Compliance Status</h2>
+<p>This website is partially compliant with the Web Content Accessibility Guidelines (WCAG) 2.2 AA standard, due to the non-compliances listed below.</p>
+<p>
+
+</p>
+<p>The
+full guidelines are available at:</p>
+<p>
+
+</p>
+<p><a href="https://www.w3.org/TR/WCAG22/">Web
+Content Accessibility Guidelines (WCAG) 2.2 AA standard</a></p>
+<p>
+
+</p>
+<h2>Non accessible content</h2>
+<p>
+
+</p>
+<p>The
+content listed below is non-accessible for the following reasons.</p>
+<p></p>
+<h3>Noncompliance with the accessibility regulations
+
+
+</h3>
+
+
+</p>
+<p>
+
+</p>
+
+
+<!-- {{Add sections which apply to this statement}} -->
+<!-- {{Maintain the formatting of the items, as shown below in the examples below}} -->
+
+<ul><li>Content overlap occurs in both portrait and landscape views on mobile devices</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#orientation">1.3.4 - Orientation</a></p>
+
+<ul><li>Some links are not underlined and rely on colour alone</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#use-of-color">1.4.1 - Use of Colour</a></p>
+
+<ul><li>There are instances of text presented as images</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#images-of-text">1.4.5 - Images of Text</a></p>
+
+<ul><li>Pages do not reflow when zooming beyond 200%</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#reflow">1.4.10 - Reflow</a></p>
+
+<ul><li>Tabbing order in the navigation menu is illogical and does not follow a consistent left-to-right reading order</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#meaningful-sequence">1.3.2 - Meaningful Sequence</a></p>
+<p><a href="https://www.w3.org/TR/WCAG22/#focus-order">2.4.3 - Focus Order</a></p>
+
+<ul><li>Several links throughout the site are not formatted with meaningful hypertext</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#link-purpose-in-context">2.4.4 - Link Purpose (In Context)</a></p>
+
+<ul><li>Content is not robust enough that it can be interpreted by a wide variety of user agents, including assistive technologies e.g. some form elements do not have labels and some select elements do not have accessible names</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#name-role-value">4.1.2 - Name, Role, Value</a></p>
+
+<ul><li>There are PDFs that are not fully accessible</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1 - Non‑text Content</a><p>
+<p><a href="https://www.w3.org/TR/WCAG22/#keyboard">2.1.1 - Keyboard</a></p>
+<p><a href="https://www.w3.org/TR/WCAG22/#name-role-value">4.1.2 - Name, Role, Value</a></p>
+
+
+<p>We
+aim to improve our websites accessibility on a regular and continuous
+basis. See the section below ('What we're doing to improve
+accessibility') on how we are improving our site accessibility. 
+</p>
+<p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect}} -->
+<!-- {{Add DATE_FOR_IMPROVEMENTS = Date Statement was approved + 11 months}} -->
+</p>
+<p>We
+are working towards solving these problems and expect significant
+improvements by June 2026. The site is fully within our control.</p>
+<p>
+
+<!-- {{The statement may make claims of disproportionate burden, double-check that it matches below}} -->
+
+</p>
 <h3>Disproportionate burden</h3>
-<p>We are not currently claiming that any&nbsp;accessibility problems would be a disproportionate burden to fix.&nbsp;</p>
-<h3>Content that is not within the Scope of the Accessibility Regulations</h3>
-<p>At this time we are not claiming that any content is out of scope.</p>
-<h2>What we're doing to improve accessibility</h2>
-<p>We will continue to work with our in house developers to address these issues and deliver a solution or suitable workaround and correct issues directly where they are under our control. This website was developed in-house for the project.</p>
-<p>We will continue to monitor accessibility and will carry out further accessibility testing if significant changes are made to the user interface or if a service user raises an issue. To plan to resolve the issues that are within our control by July 2022. We plan to manual review the accessibility of the site and make improvements and update this statement before July 2022.Where we are unable to resolve an issue or where an issue is out with our control we will ensure reasonable adjustments are put in place to ensure no user is disadvantaged</p>
-<h3>Information Services and accessibility</h3>
-<p>Information Services (IS) has further information on accessibility including assistive technology, creating accessible documents, and services IS provides for disabled users.</p>
-<p><a href="https://www.ed.ac.uk/information-services/help-consultancy/accessibility">Assistive technology, creating accessible documents, and services IS provides for disabled users</a></p>
+<p>
+We
+are not currently claiming that any accessibility problems would be a
+disproportionate burden to fix.</p>
+<p>
+
+<!-- {{The statement may make claims of not within scope of regulations, double-check that it matches below}} -->
+
+</p>
+<h3>Content that’s not within the scope of the accessibility regulations</h3>
+<p>
+
+</p>
+<p>At
+this time we believe no content is outwith the scope of the accessibility regulations.</p>
+<p>
+
+</p>
+<h2>What we’re doing to improve accessibility</h2>
+<p>
+
+</p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect}} -->
+<!-- {{Add DATE_FOR_IMPROVEMENTS = Date Statement was approved + 11 months}} -->
+
+<p>We
+will continue to address and make significant improvements to the
+accessibility issues highlighted. Unless specified otherwise, a
+complete solution or significant improvement will be in place by June 2026.
+<p>
+
+</p>
+<p>While
+we are in the process of resolving these accessibility issues we will
+ensure reasonable adjustments are in place to make sure no user is
+disadvantaged. As changes are made, we will continue to review
+accessibility and retest the accessibility of this website.</p>
+<p>
+
+</p>
+<p>
+
+<!-- {{Add the required dates to this section}} -->
+<!-- {{FIRST_STATEMENT_DATE = the date of the FIRST version of this statement - check the currently published version of the site for the date to use}} -->
+<!-- {{LAST_REVIEW_DATE = the date this version of the statement was approved by Viki's team }} -->
+<!-- {{TESTING_DATE = the date this version of the statement was tested.  If it was tested over multiple days then use the last day}} -->
+
+</p>
 <h2>Preparation of this accessibility statement</h2>
-<p><strong>This statement was prepared on 15<sup>th</sup> September 2021. It was last reviewed on 15<sup>th</sup> September 2021</strong><strong>.</strong></p>
-<p>This website was last tested on 7<sup>th</sup> August 2020. The test was carried out by The University Library and University Collections Digital Library team using the automated LittleForest tool. The website is scheduled for manual testing by July 2022.</p>
-<p>We did not use sample pages for testing - all pages were run through LittleForest.</p>
-<p>Little Forrest claims it tests the following WCAG criteria either partially or wholly</p>
-<table width="0">
-<tbody>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.1.1</p>
-    </td>
-    <td width="250">
-        <p>Non-text Content</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.2.1</p>
-    </td>
-    <td width="250">
-        <p>Audio-only and Video-only (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.2.2</p>
-    </td>
-    <td width="250">
-        <p>Captions (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.2.3</p>
-    </td>
-    <td width="250">
-        <p>Audio Description or Media Alternative (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.3.1</p>
-    </td>
-    <td width="250">
-        <p>Info and Relationships</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.3.2</p>
-    </td>
-    <td width="250">
-        <p>Meaningful Sequence</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.3.3</p>
-    </td>
-    <td width="250">
-        <p>Sensory Characteristics</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.4.1</p>
-    </td>
-    <td width="250">
-        <p>Use of Color</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>1.4.2</p>
-    </td>
-    <td width="250">
-        <p>Audio Control</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.1.1</p>
-    </td>
-    <td width="250">
-        <p>Keyboard</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.1.2</p>
-    </td>
-    <td width="250">
-        <p>No Keyboard Trap</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.2.1</p>
-    </td>
-    <td width="250">
-        <p>Timing Adjustable</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.2.2</p>
-    </td>
-    <td width="250">
-        <p>Pause, Stop, Hide</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.3.1</p>
-    </td>
-    <td width="250">
-        <p>Three Flashes or Below Threshold</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.4.1</p>
-    </td>
-    <td width="250">
-        <p>Bypass Blocks</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.4.2</p>
-    </td>
-    <td width="250">
-        <p>Page Titled</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.4.3</p>
-    </td>
-    <td width="250">
-        <p>Focus Order</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>2.4.4</p>
-    </td>
-    <td width="250">
-        <p>Link Purpose (In Context)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>3.1.1</p>
-    </td>
-    <td width="250">
-        <p>Language of Page</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>3.2.1</p>
-    </td>
-    <td width="250">
-        <p>On Focus</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>3.2.2</p>
-    </td>
-    <td width="250">
-        <p>On Input</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>3.3.1</p>
-    </td>
-    <td width="250">
-        <p>Error Identification</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>3.3.2</p>
-    </td>
-    <td width="250">
-        <p>Labels or Instructions</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>4.4.1</p>
-    </td>
-    <td width="250">
-        <p>Parsing</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.0</p>
-    </td>
-    <td width="49">
-        <p>A</p>
-    </td>
-    <td width="76">
-        <p>4.4.2</p>
-    </td>
-    <td width="250">
-        <p>Name, Role, Value</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.2.4</p>
-    </td>
-    <td width="250">
-        <p>Captions (Live)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.2.5</p>
-    </td>
-    <td width="250">
-        <p>Audio Description (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.4.3</p>
-    </td>
-    <td width="250">
-        <p>Contrast (Minimum)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.4.4</p>
-    </td>
-    <td width="250">
-        <p>Resize Text</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.4.5</p>
-    </td>
-    <td width="250">
-        <p>Images of Text</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>2.4.5</p>
-    </td>
-    <td width="250">
-        <p>Multiple Ways</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>2.4.6</p>
-    </td>
-    <td width="250">
-        <p>Headings and Labels</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>2.4.7</p>
-    </td>
-    <td width="250">
-        <p>Focus Visible</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>3.1.2</p>
-    </td>
-    <td width="250">
-        <p>Language of Parts</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>3.2.3</p>
-    </td>
-    <td width="250">
-        <p>Consistent Navigation</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>3.2.4</p>
-    </td>
-    <td width="250">
-        <p>Consistent Identification</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>3.3.3</p>
-    </td>
-    <td width="250">
-        <p>Error Suggestion</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>3.3.4</p>
-    </td>
-    <td width="250">
-        <p>Error Prevention (Legal, Financial, Data)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.2.6</p>
-    </td>
-    <td width="250">
-        <p>Sign Language (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.2.7</p>
-    </td>
-    <td width="250">
-        <p>Extended Audio Description (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.2.8</p>
-    </td>
-    <td width="250">
-        <p>Media Alternative (Prerecorded)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.2.9</p>
-    </td>
-    <td width="250">
-        <p>Audio-only (Live)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.4.6</p>
-    </td>
-    <td width="250">
-        <p>Contrast (Enhanced)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.4.7</p>
-    </td>
-    <td width="250">
-        <p>Low or No Background Audio</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.4.8</p>
-    </td>
-    <td width="250">
-        <p>Visual Presentation</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>1.4.9</p>
-    </td>
-    <td width="250">
-        <p>Images of Text (No Exception)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.1.3</p>
-    </td>
-    <td width="250">
-        <p>Keyboard (No Exception)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.2.3</p>
-    </td>
-    <td width="250">
-        <p>No Timing</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.2.4</p>
-    </td>
-    <td width="250">
-        <p>Interruptions</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.2.5</p>
-    </td>
-    <td width="250">
-        <p>Re-authenticating</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.3.2</p>
-    </td>
-    <td width="250">
-        <p>Three Flashes</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.4.8</p>
-    </td>
-    <td width="250">
-        <p>Location</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.4.9</p>
-    </td>
-    <td width="250">
-        <p>Link Purpose (Link Only)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>2.4.10</p>
-    </td>
-    <td width="250">
-        <p>Section Headings</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.1.3</p>
-    </td>
-    <td width="250">
-        <p>Unusual Words</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.1.4</p>
-    </td>
-    <td width="250">
-        <p>Abbreviations</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.1.5</p>
-    </td>
-    <td width="250">
-        <p>Reading</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.1.6</p>
-    </td>
-    <td width="250">
-        <p>Pronunciation</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.2.5</p>
-    </td>
-    <td width="250">
-        <p>Change on Request</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.3.5</p>
-    </td>
-    <td width="250">
-        <p>Help</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AAA</p>
-    </td>
-    <td width="76">
-        <p>3.3.6</p>
-    </td>
-    <td width="250">
-        <p>Error Prevention (All)</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.3.4</p>
-    </td>
-    <td width="250">
-        <p>Orientation</p>
-    </td>
-</tr>
-<tr>
-    <td width="73">
-        <p>WCAG 2.1</p>
-    </td>
-    <td width="49">
-        <p>AA</p>
-    </td>
-    <td width="76">
-        <p>1.3.5</p>
-    </td>
-    <td width="250">
-        <p>Identify Input Purpose</p>
-    </td>
-</tr>
-</tbody>
-</table>
+<p><b>This statement was prepared on 15th September 2021. It was last reviewed on 18th July 2025.</b></p> 
+
+<p><b>The website was last tested on 15th July 2025. The
+testing was carried out by Library
+and University Collections, Information Services Group at the University of Edinburgh</b> using
+both automated and manual methods. The site was tested on a PC,
+primarily using Microsoft Edge alongside Mozilla Firefox and Google
+Chrome.</p>
+<p>
+
+</p>
+<p>Recent
+world-wide usage levels survey for different screen readers and
+browsers shows that Chrome, Mozilla Firefox and Microsoft Edge are
+increasing in popularity and Google Chrome is now the favoured
+browser for screen readers:</p>
+<p>
+
+</p>
+<p><a href="https://webaim.org/projects/screenreadersurvey9/">WebAIM:
+Screen Reader User Survey</a></p>
+<p>
+
+</p>
+<p>The
+aforementioned three browsers have been used in certain questions for
+reasons of breadth and variety.</p>
+<p>
+
+</p>
+<p>We
+ran automated testing using <a href="https://www.deque.com/axe/devtools/chrome-browser-extension/">AXE Devtools</a> and
+then manual testing that included:</p>
+
+<!-- {{Check the items on the list below match with the approved statement - add/delete as appropriate}} -->
+
+<ul>
+	<li>Spell
+	check functionality;</li>
+	<li>Scaling
+	using different resolutions and reflow;</li>
+	<li>Options
+	to customise the interface (magnification, font, background colour,
+	etc);</li>
+	<li>Keyboard
+	navigation and keyboard traps;</li>
+	<li>Data
+	validation;</li>
+	<li>Warning
+	of links opening in new tab or window;</li>
+	<li>Information
+	conveyed in the colour or sound only;</li>
+	<li>Flashing,
+	moving or scrolling text;</li>
+	<li>Use
+	with screen reading software (for example JAWS);</li>
+	<li>Assistive
+	software (TextHelp Read and Write, Windows Magnifier, ZoomText,
+	Dragon Naturally Speaking, TalkBack and VoiceOver);</li>
+	<li>Tooltips
+	and text alternatives for any non-text content;</li>
+	<li>Time
+	limits;</li>
+	<li>Compatibility
+	with mobile accessibility functionality (Android and iOS);</li>
+	<li>Any
+	drag functionality and alternatives;</li>
+	<li>Consistent
+	help function;</li>
+	<li>Submission and re-entry of data;</li>
+	<li>Any
+	cognitive tests.
+	</li>
+</ul>
+
+<!-- {{Delete the entire Change Log section if this is the first manual test - i.e. no fixes have been implemented}} -->
+<!-- {{The fixes should be grouped by date.  They should contain a description of the fix and the WCAG element referred to - see example below. Entries should follow the same format as below}} -->
+
+<h2>Change Log</h2
+<p>
+Since the previous test, the following fixes were implemented in August 2024 based on the manual testing done.</p>
+<p>
+</p>
+
+<ul><li>All colour contrast issues have been resolved to meet WCAG 2.2 AA standards. (August 16, 2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></p>
+
+<ul><li>Replaced the carousel with a grid of static images. (August 16, 2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#pause-stop-hide">2.2.2 - Pause, Stop, Hide</a></p>
+
+<ul><li>Added a skip to main content button on each page. (August 16, 2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#bypass-blocks">2.4.1 - Bypass Blocks</a></p>
+
+<ul><li>Implemented a consistent, high contrast focus highlighter function website wide. (August 16, 2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#focus-visible">2.4.7 - Focus Visible</a></p>
+
+<ul><li>Added notification to let users that a new tab is about to be opened after clicking on a link. (August 16, 2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#on-input">3.2.2 - On input</a></p>
+
+<ul><li>Removed all instances of continuous capitals and some instances of italic text that were not links. (August 16, 2024)</li></ul>
+
+<ul><li>Increased font size to at least 12pt. (August 16, 2024)</li></ul>
+
+<p>
+</p>
+</body>
 </html>

--- a/static/stcecilias/accessibility.php
+++ b/static/stcecilias/accessibility.php
@@ -1,199 +1,481 @@
-<html>
-    <h1>Accessibility statement for <a href="https://collections.ed.ac.uk/stcecilias">St Cecilia&rsquo;s Hall </a></h1>
-    <p>Website accessibility statement in line with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</p>
-    <p>This accessibility statement applies to: <a href="https://collections.ed.ac.uk/stcecilias">https://collections.ed.ac.uk/stcecilias</a></p>
+<!DOCTYPE html>
+<html lang="en">
 
-    <p>This website is run by the Library and University Collections Directorate which is part of Information Services Group at the University of Edinburgh. We want as many people as possible to be able to use this website. For example, that means you should be able to:</p>
-    <ul>
-        <li>using your browser settings, change colours, contrast levels and fonts to some extent;</li>
-        <li>scale to 200% without loss of content;</li>
-        <li>navigate most of the website using just a keyboard;</li>
-        <li>experience no time limits when using the site;</li>
-        <li>not encounter any flashing, scrolling or moving text.</li>
-    </ul>
+<!-- Search for the double curly bracket chars to navigate to areas to change in this template e.g. Ctrl+F "{{" -->
 
-    <h2>Customising the website</h2>
-    <p>AbilityNet has advice on making your device easier to use if you have a disability. This is an external site with suggestions to make your computer more accessible:</p>
-    <p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet - My computer my way</a></p>
-    <p>With a few simple steps you can customise the appearance of our website using your browser settings to make it easier to read and navigate:</p>
-    <p><a href="https://www.ed.ac.uk/about/website/accessibility/customising-site">Additional information on how to customise our website appearance</a></p>
-    <p>If you are a member of University staff or a student, you can use the free SensusAccess accessible document conversion service:</p>
-    <p><a href="https://www.ed.ac.uk/student-disability-service/staff/supporting-students/accessible-technology">Information on SensusAccess</a></p>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<title>Accessibility Statement</title>
+    <style type="text/css">
+		@page { size: 21cm 29.7cm; margin: 2.54cm }
+		body, p { font-family: Arial, sans-serif; font-size: 12pt; line-height: 1.5; text-align: left; direction: ltr; background: transparent; padding:0; margin:0; }
+		h1, h2, h3 { color: #2f5496; text-align: left; margin-bottom: 0.5cm; direction: ltr; background: transparent; page-break-after: avoid }
+		h1 { font-size: 24pt; }
+		h2 { font-size: 20pt; }
+		h3 { font-size: 16pt; }
+		a:link, a:visited { color: #0563c1; text-decoration: underline }
+        body > *:not(.container-fluid), footer { display: none; }
+        .container-full {width:95%; margin:auto; padding:1em;}
+	</style>
 
-    <h2>How accessible this website is</h2>
-    <p>We know some parts of this website are not fully accessible:</p>
-    <ul>
-        <li>not all links purposes are clear to the user;</li>
-        <li>some body text is smaller than 12 point;</li>
-        <li>not all non-text content presented to users has alternative text;</li>
-        <li>not all colour contrasts meet the recommended Web Content Accessibility Guidelines 2.1 AA standard;</li>
-        <li>it is not always clear where a user has navigated to using a keyboard;</li>
-        <li>similarly, users may not be able to access all content by using the keyboard alone;</li>
-        <li>some links open in new windows or tabs without warning;</li>
-        <li>the site is not fully compatible with screen reading software;</li>
-        <li>the site is not fully compatible with voice recognition software;</li>
-        <li>some parts of the website cannot be customised depending on the browser used;</li>
-        <li>you cannot magnify the site above 240% without text overlapping;</li>
-        <li>some text may not experience reflow in a single column when you change the size of the browser window and at certain levels of magnification;</li>
-        <li>there is no ‘skip to main content’ function;</li>
-        <li>some tooltips do not appear when using the keyboard.</li>
-    </ul>
+</head>
+<body lang="en-GB" link="#0563c1" vlink="#954f72" dir="ltr">
 
-    <h2>Feedback and contact information</h2>
-    <p>If you need information on this website in a different format, including accessible PDF, large print, audio recording or braille:</p>
-    <ul>
-        <li>Email: <a href="mailto:HeritageCollections@ed.ac.uk">HeritageCollections@ed.ac.uk</a></li>
-        <li>Telephone: +44 (0)131 650 8379</li>
-        <li>British Sign Language (BSL) users can contact us via Contact Scotland BSL, the on-line BSL interpreting service: <a href="https://contactscotland-bsl.org/">Contact Scotland BSL</a></li>
-    </ul>
 
-    <h2>Reporting accessibility problems with this website</h2>
-    <p>We are always looking to improve the accessibility of this website. If you find any problems not listed on this page, or think we're not meeting accessibility requirements, please contact:</p>
-    <ul>
-        <li>Email: <a href="mailto:HeritageCollections@ed.ac.uk">HeritageCollections@ed.ac.uk</a></li>
-        <li>Telephone: +44 (0)131 650 8379</li>
-        <li>British Sign Language (BSL) users can contact us via Contact Scotland BSL, the on-line BSL interpreting service: <a href="https://contactscotland-bsl.org/">Contact Scotland BSL</a></li>
-    </ul>
-    <p>We will consider your request and get back to you in 5 working days.</p>
+<h1>Accessibility
+Statement for <a href="https://collections.ed.ac.uk/stcecilias/">St Cecilia's Hall</a></h1>
+</p>
+<p>
 
-    <h2>Enforcement procedure</h2>
-    <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint please contact the Equality Advisory and Support Service (EASS) directly:</p>
-    <p><a href="https://www.equalityadvisoryservice.com/">Contact details for the Equality Advisory and Support Service (EASS)</a></p>
-    <p>The government has produced information on how to report accessibility issues:</p>
-    <p><a href="https://www.gov.uk/reporting-accessibility-problem-public-sector-website">Reporting an accessibility problem on a public sector website</a></p>
+</p>
+<p>Website accessibility statement inline with Public Sector Body (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</p>
+<p>
 
-    <h2>Contacting us by phone using British Sign Language</h2>
-    <p>British Sign Language service Contact Scotland BSL runs a service for British Sign Language users and all of Scotland’s public bodies using video relay. This enables sign language users to contact public bodies and vice versa. The service operates 24 hours a day, 7 days a week.</p>
-    <p><a href="https://contactscotland-bsl.org/">Contact Scotland BSL service details</a></p>
+</p>
+<p>This accessibility statement applies to:</p>
+<p><a href="https://collections.ed.ac.uk/stcecilias/">https://collections.ed.ac.uk/stcecilias/</a>
+</p>
 
-    <h2>Technical information about this website&rsquo;s accessibility</h2>
-    <p>The University of Edinburgh is committed to making its websites and applications accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-    <p>This website is partially compliant with the Web Content Accessibility Guidelines (WCAG) 2.1 AA standard, due to the non-compliances listed below.</p>
-    <p>The full guidelines are available at:</p>
-    <p>&nbsp;<a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a></p>
-    <h3>Non accessible content</h3>
-    <p>The content listed below is non-accessible for the following reasons.</p>
-    <h3>Noncompliance with the accessibility regulations</h3>
-    <p>The following items to not comply with the WCAG 2.1 AA success criteria:</p>
-    <ul>
-        <li>Not all non-text content presented to users has alternative text
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#non-text-content">1.1.1 - Non-text Content</a></li>
-            </ul>
-        </li>
-        <li>Information, structure and relationships conveyed through presentation cannot always be programmatically determined. This includes missing heading tags
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">1.3.1 - Info and Relationships</a></li>
-                <li><a href="https://www.w3.org/TR/WCAG21/#headings-and-levels">2.4.6 Headings and Labels (Level AA)</a></li>
-            </ul>
-        </li>
-        <li>There may not be sufficient colour contrast between font and background colours, especially where the text size is small
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></li>
-            </ul>
-        </li>
-        <li>Site is not fully compatible with browser customisation meaning that users do not have full control and functionality when customising the site (WCAG 2.1 AAA)
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#visual-presentation">1.4.8 - Visual Presentation (AAA) </a></li>
-            </ul>
-        </li>
-        <li>When pages are magnified the content does not reflow
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#reflow">1.4.10 - Reflow</a></li>
-            </ul>
-        </li>
-        <li>Some tooltips, which appear on mouse hover, do not do so when using the keyboard to navigate
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus">1.4.13 - Content on Hover or Focus</a></li>
-            </ul>
-        </li>
-        <li>It is not possible to use a keyboard to access all the content
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#keyboard">2.1.1 - Keyboard</a></li>
-            </ul>
-        </li>
-        <li>There is no ‘skip to main content’ option available throughout the website
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#bypass-blocks">2.4.1 Bypass Blocks</a></li>
-            </ul>
-        </li>
-        <li>Some of our page titles do not fully describe the page content and some pages are missing titles
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#page-titled">2.4.2 - Page Titled</a></li>
-            </ul>
-        </li>
-        <li>The purpose of each link cannot be determined from the text alone
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context">2.4.4 - Link Purpose (In Context)</a></li>
-            </ul>
-        </li>
-        <li>Information, structure and relationships conveyed through presentation cannot always be programmatically determined. This includes missing headings
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#headings-and-labels">2.4.6 – Headings and Labels</a></li>
-            </ul>
-        </li>
-        <li>Visual information to identify user interface components, such as keyboard focus, do not always have a sufficient contrast ratio
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#focus-visible">2.4.7 – Focus Visible</a></li>
-            </ul>
-        </li>
-        <li>Mobile touch targets are less than 9mm by 9mm apart
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#target-size">2.5.5 - Target Size</a></li>
-            </ul>
-        </li>
-        <li>Some links open in a new browser window without warning
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#on-input">3.2.2 - On Input</a></li>
-            </ul>
-        </li>
-        <li>The website is not fully compatible with screen readers and voice recognition software
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#parsing">4.1.1 Parsing</a></li>
-            </ul>
-        </li>
-        <li>Screen readers are not able to identify some parts of the page
-            <ul>
-                <li><a href="https://www.w3.org/TR/WCAG21/#name-role-valuet">4.1.2 - Name, Role, Value</a></li>
-            </ul>
-        </li>
-    </ul>
-    <p>At this time, we believe all items are within our control. Unless specified otherwise, a complete solution, or significant improvement, will be in place for those items within our control by March 2024.</p>
-    <h3>Disproportionate burden</h3>
-    <p>We are not currently claiming that any accessibility problems would be a disproportionate burden to fix.</p>
-    <h3>Content that's not within the scope of the accessibility regulations</h3>
-    <p>At this time, we do not believe that any content is outside the scope of the accessibility regulations.</p>
+<p>
+</p>
 
-    <h2>What we're doing to improve accessibility</h2>
-    <p>At this time, we believe all items are within our control. We will continue to address the accessibility issues highlighted to deliver a solution or suitable workaround. We are looking to move this site to a new content management system within the next 12 months and will be working to ensure this resolves the accessibility issues. Unless specified otherwise, a complete solution or significant improvement will be in place for those items within our control by March 2024.</p>
-    <p>While we are in the process of resolving these accessibility issues, or where we are unable, we will ensure reasonable adjustments are in place to make sure no user is disadvantaged. As changes are made, we will continue to review accessibility and retest the accessibility of this website.</p>
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect and will need to be edited}} -->
 
-    <h2>Preparation of this accessibility statement</h3>
-    <p><strong>This statement was prepared on 10th September 2020. It was last reviewed on 21st February 2023.</strong></p>
-    <p>This website was first tested on 10th September 2020 and reviewed on 15th September 2021. The testing was carried out by The University of Edinburgh Library and University Collections Digital Library Development team using the automated <a href="https://wave.webaim.org/">Wave WEBAIM</a> and <a href="https://littleforest.co.uk/">Little Forest</a> testing tool. The testing in October 2022 included full manual as well as automated testing.</p>
-    <p>The website was last manually tested in September 2022 by the Digital Library team, Library and University Collections, University of Edinburgh following on from automated testing for the previous two years. This was primarily using Mozilla Firefox (91.7.1esr), Microsoft Edge (99.0.1150.55), and Google Chrome (99.0.4844.84), browsers for comparative purposes.</p>
-    <p>Recent world-wide usage levels survey for different screen readers and browsers shows that Chrome, Mozilla Firefox and Microsoft Edge are increasing in popularity and Google Chrome is now the favoured browser for screen readers:</p>
-    <p><a href="https://webaim.org/projects/screenreadersurvey9/">WebAIM: Screen Reader User Survey</a></p>
-    <p>The aforementioned three browsers have been used in certain questions for reasons of breadth and variety.</p>
-    <p>We ran automated testing using <a href="https://wave.webaim.org/">Wave WEBAIM</a> and <a href="https://littleforest.co.uk/">Little Forest</a> then manual testing that included:</p>
-    <ul>
-        <li>Spell check functionality;</li>
-        <li>Scaling using different resolutions and reflow;</li>
-        <li>Options to customise the interface (magnification, font, background colour, etc);</li>
-        <li>Keyboard navigation and keyboard traps;</li>
-        <li>Data validation;</li>
-        <li>Warning of links opening in a new tab or window;</li>
-        <li>Information conveyed in colour or sound only;</li>
-        <li>Flashing, moving or scrolling text;</li>
-        <li>Operability if JavaScript is disabled;</li>
-        <li>Use with screen reading software (for example, JAWS);</li>
-        <li>Assistive software (TextHelp Read and Write, Windows Magnifier, ZoomText, Dragon NaturallySpeaking, TalkBack and VoiceOver);</li>
-        <li>Tooltips and text alternatives for any non-text content;</li>
-        <li>Time limits;</li>
-        <li>Compatibility with mobile accessibility functionality (Android and iOS).</li>
-    </ul>
+<p>This website is run by the Library and University Collections Directorate, Information Services Group at the University of Edinburgh. We want as many people as possible to be
+able to use this application. For example, that means you should be
+able to:</p>
+<p>
 
-    <h2>Change Log</h2>
-    <p>Since our first evaluation and statement, which was based on automated testing, we have undertaken extensive manual testing. This includes utilising a range of assistive technology to ensure we have a clear picture of the accessibility issues and how best to resolve them.</p>
+<!-- {{This sections varies. Check the items listed below match with the approved Statement - add/delete items as necessary }} -->
 
+</p>
+<ul>
+<li>Use browser settings to change colours, contrast levels and fonts</li>
+<li>Navigate most of the website using just a keyboard</li>
+<li>Listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+<li>Navigate most of the site using voice recognition software (e.g. Dragon NaturallySpeaking)</li>
+<li>Experience no time limits when using the website</li>
+<li>Use the site without encountering any scrolling, flashing or moving text</li>
+</ul>
+<p>
+
+</p>
+<p>We’ve also made the website text as simple as possible to understand. However, some of our content is technical, and we use technical terms where there is no easier wording we could use without changing what the text means.</p>
+<p>
+
+</p>
+<h2>Customising the website</h2>
+<p>
+AbilityNet
+has advice on making your device easier to use if you have a
+disability. This is an external site with suggestions to make your
+computer more accessible:</p>
+<p>
+
+</p>
+<p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet
+- My Computer My Way</a></p>
+<p>
+
+</p>
+<p>With
+a few simple steps you can customise the appearance of our website
+using your browser settings to make it easier to read and navigate:</p>
+<p>
+
+</p>
+<p><a href="https://www.ed.ac.uk/about/website/accessibility/customising-site" target="Customising our site">Additional
+information on how to customise our website appearance</a></p>
+<p>
+
+</p>
+<p>If
+you are a member of University staff or a student, you can use the free SensusAccess accessible document conversion service:</p>
+<p>
+
+</p>
+<p><a href="https://www.ed.ac.uk/student-disability-service/staff/supporting-students/accessible-technology">Information
+on SensusAccess</a></p>
+<p>
+
+</p>
+<h2>How accessible this website is</h2>
+<p>
+
+</p>
+<p>We know some parts of this website are not fully accessible:</p>
+<p>
+
+</p>
+
+<!-- {{This section varies according to the site. Edit as appropriate}} -->
+
+<ul>
+<li>Not all links purposes are clear to the user;</li>
+<li>Not all non-text content presented to users has alternative text;</li>
+<li>Not all colour contrasts meet the recommended Web Content Accessibility Guidelines 2.1 AA standard;</li>
+<li>Users may not be able to access all content by using the keyboard alone;</li>
+<li>The site is not fully compatible with assistive software such as voice recognition software or screen reader software;</li>
+<li>You cannot magnify the site above 240% without text overlapping;</li>
+<li>Reflow is not enabled to 400% on all content;</li>
+<li>There are PDF’s that are not fully accessible;</li>
+<li>Some headings are coded incorrectly and some heading levels are missed;</li>
+
+
+</ul>
+<p>
+
+</p>
+<h2>Feedback and contact information</h2>
+<p>
+
+</p>
+<p>If
+you need information on this website in a different format, including
+accessible portable document format (PDF), large print, audio recording or braille:
+</p>
+
+<!-- {{You may need to change the contact details if the site is not within the control of L&UC}} -->
+
+
+<ul>
+	<li>Email: <a href="mailto:Information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></li>
+	<li>Telephone: +44 (0)131 651 5151</li>
+	<li>Use the <a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline online contact form</a></li>
+	<li>British Sign Language (BSL) users can contact us via <a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL</a>, the on-line BSL interpreting service.
+</ul>
+
+<p>We’ll consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
+<h2>Reporting accessibility problems with this website</h2>
+<p>
+We are always looking to improve the accessibility of this website. If
+you find any problems not listed on this page, or think we’re not
+meeting accessibility requirements, please contact:&nbsp;
+
+
+</p>
+
+<!-- {{You may need to change the contact details if the site is not within the control of L&UC}} -->
+
+<ul>
+	<li>Email: <a href="mailto:Information.systems@ed.ac.uk">Information.systems@ed.ac.uk</a></li>
+	<li>Telephone: +44 (0)131 651 5151</li>
+	<li>Use the <a href="https://www.ishelpline.ed.ac.uk/forms/">IS Helpline online contact form</a></li>
+	<li>British Sign Language (BSL) users can contact us via <a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL</a>, the on-line BSL interpreting service.
+</ul>
+<p>We'll consider your request and get back to you in 5 working days.</p>
+<p>
+
+</p>
+<h2>Enforcement procedure</h2>
+<p>
+The
+Equality and Human Rights Commission (EHRC) is responsible for
+enforcing the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018 (the ‘accessibility
+regulations’). If you’re not happy with how we respond to your
+complaint please contact the Equality Advisory and Support Service
+(EASS) directly:</p>
+<p>
+
+</p>
+<p><a href="https://www.equalityadvisoryservice.com/">Contact
+details for the Equality Advisory and Support Service (EASS)</a></p>
+<p>
+
+</p>
+<p>The
+government has produced information on how to report accessibility
+issues:</p>
+<p>
+
+</p>
+<p><a href="https://www.gov.uk/reporting-accessibility-problem-public-sector-website">Reporting
+an accessibility problem on a public sector website</a></p>
+<p>
+
+</p>
+<h2>Contacting us by phone using British Sign Language</h2>
+<p>
+British
+Sign Language service</p>
+<p>Contact
+Scotland BSL runs a service for British Sign Language users and all
+of Scotland’s public bodies using video relay. This enables sign
+language users to contact public bodies and vice versa. The service
+operates from 8.00am to 12.00am, 7 days a week.</p>
+<p><a href="https://contactscotland-bsl.org/">Contact
+Scotland BSL service details.</a></p>
+<p>
+
+
+</p>
+<h2>Technical information about this website’s accessibility</h2>
+<p>The
+University of Edinburgh is committed to making its websites and
+applications accessible, in accordance with the Public Sector Bodies
+(Websites and Mobile Applications) (No. 2) Accessibility Regulations
+2018.</p>
+<p>
+
+</p>
+<h2>Compliance Status</h2>
+<p>This website is partially compliant with the Web Content Accessibility Guidelines (WCAG) 2.2 AA standard, due to the non-compliances listed below.</p>
+<p>
+
+</p>
+<p>The
+full guidelines are available at:</p>
+<p>
+
+</p>
+<p><a href="https://www.w3.org/TR/WCAG22/">Web
+Content Accessibility Guidelines (WCAG) 2.2 AA standard</a></p>
+<p>
+
+</p>
+<h2>Non accessible content</h2>
+<p>
+
+</p>
+<p>The
+content listed below is non-accessible for the following reasons.</p>
+<p></p>
+<h3>Noncompliance with the accessibility regulations
+
+
+</h3>
+
+</p>
+<p>
+
+</p>
+
+
+<!-- {{Add sections which apply to this statement}} -->
+<!-- {{Maintain the formatting of the items, as shown below in the examples below}} -->
+
+<ul><li>Not all non-text content presented to users has alternative text.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#non-text-content">1.1.1 - Non-text Content</a></p>
+
+<ul><li>Information, structure and relationships conveyed through presentation cannot always be programmatically determined. This includes missing heading tags.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#info-and-relationships">1.3.1 - Info and Relationships</a></p>
+<p><a href="https://www.w3.org/TR/WCAG22/#headings-and-labels">2.4.6 - Headings and Labels</a></p>
+
+<ul><li>There may not be sufficient colour contrast between font and background colours.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></p>
+
+<ul><li>It is not possible to magnify all content to 200% without loss of content.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#resize-text">1.4.4 - Resize text</a></p>
+
+<ul><li>When pages are magnified the content does not reflow.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#reflow">1.4.10 - Reflow</a></p>
+
+<ul><li>Some tooltips, which appear on mouse hover, do not do so when using the keyboard to navigate.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus">1.4.13 - Content on Hover or Focus</a></p>
+
+<ul><li>It is not possible to use a keyboard to access all the content.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#keyboard">2.1.1 - Keyboard</a></p>
+
+<ul><li>Some of our page titles do not fully describe the page content and some pages are missing titles.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#page-titled">2.4.2 - Page Titled</a></p>
+
+<ul><li>The purpose of each link cannot be determined from the text alone.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#link-purpose-in-context">2.4.4 - Link Purpose (In Context)</a></p>
+
+<ul><li>Mobile touch targets are less than 9mm by 9mm apart.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#target-size">2.5.5 - Target Size</a></p>
+
+<ul><li>There are missing labels present in the website that fail to describe the purpose of the input form.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#labels-or-instructions">3.3.2 - Labels or Instructions</a></p>
+
+<ul><li>The site is not fully compatible with assistive software such as screen readers or voice recognition software e.g. elements do not only use supported ARIA attributes.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#name-role-value">4.1.2 - Name, Role, Value</a></p>
+
+<ul><li>There are PDFs that are not fully accessible.</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#keyboard">2.1.1 - Keyboard</a></p>
+<p><a href="https://www.w3.org/TR/WCAG22/#name-role-value">4.1.2 - Name, Role, Value</a></p>
+
+
+<p>We
+aim to improve our websites accessibility on a regular and continuous
+basis. See the section below ('What we're doing to improve
+accessibility') on how we are improving our site accessibility. 
+</p>
+<p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect}} -->
+<!-- {{Add DATE_FOR_IMPROVEMENTS = Date Statement was approved + 11 months}} -->
+</p>
+<p>We
+are working towards solving these problems and expect significant
+improvements by June 2026. The site is fully within our control.</p>
+<p>
+
+<!-- {{The statement may make claims of disproportionate burden, double-check that it matches below}} -->
+
+</p>
+<h3>Disproportionate burden</h3>
+<p>
+We
+are not currently claiming that any accessibility problems would be a
+disproportionate burden to fix.</p>
+<p>
+
+<!-- {{The statement may make claims of not within scope of regulations, double-check that it matches below}} -->
+
+</p>
+<h3>Content that’s not within the scope of the accessibility regulations</h3>
+<p>
+
+</p>
+<p>At
+this time we believe no content is outwith the scope of the accessibility regulations.</p>
+<p>
+
+</p>
+<h2>What we’re doing to improve accessibility</h2>
+<p>
+
+</p>
+
+<!-- {{The site may not be in full control. If it isn't, the below is likely incorrect}} -->
+<!-- {{Add DATE_FOR_IMPROVEMENTS = Date Statement was approved + 11 months}} -->
+
+<p>We
+will continue to address and make significant improvements to the
+accessibility issues highlighted. Unless specified otherwise, a
+complete solution or significant improvement will be in place by June 2026.
+<p>
+
+</p>
+<p>While
+we are in the process of resolving these accessibility issues we will
+ensure reasonable adjustments are in place to make sure no user is
+disadvantaged. As changes are made, we will continue to review
+accessibility and retest the accessibility of this website.</p>
+<p>
+
+</p>
+<p>
+
+<!-- {{Add the required dates to this section}} -->
+<!-- {{FIRST_STATEMENT_DATE = the date of the FIRST version of this statement - check the currently published version of the site for the date to use}} -->
+<!-- {{LAST_REVIEW_DATE = the date this version of the statement was approved by Viki's team }} -->
+<!-- {{TESTING_DATE = the date this version of the statement was tested.  If it was tested over multiple days then use the last day}} -->
+
+</p>
+<h2>Preparation of this accessibility statement</h2>
+<p><b>This statement was prepared on 10th September 2020. It was last reviewed on 15th July 2025.</b></p> 
+
+<p><b>The website was last tested on 15th June 2025. The
+testing was carried out by Library
+and University Collections, Information Services Group at the University of Edinburgh</b> using
+both automated and manual methods. The site was tested on a PC,
+primarily using Microsoft Edge alongside Mozilla Firefox and Google
+Chrome.</p>
+<p>
+
+</p>
+<p>Recent
+world-wide usage levels survey for different screen readers and
+browsers shows that Chrome, Mozilla Firefox and Microsoft Edge are
+increasing in popularity and Google Chrome is now the favoured
+browser for screen readers:</p>
+<p>
+
+</p>
+<p><a href="https://webaim.org/projects/screenreadersurvey9/">WebAIM:
+Screen Reader User Survey</a></p>
+<p>
+
+</p>
+<p>The
+aforementioned three browsers have been used in certain questions for
+reasons of breadth and variety.</p>
+<p>
+
+</p>
+<p>We
+ran automated testing using <a href="https://www.deque.com/axe/devtools/chrome-browser-extension/">AXE Devtools</a> and
+then manual testing that included:</p>
+
+<!-- {{Check the items on the list below match with the approved statement - add/delete as appropriate}} -->
+
+<ul>
+	<li>Spell
+	check functionality;</li>
+	<li>Scaling
+	using different resolutions and reflow;</li>
+	<li>Options
+	to customise the interface (magnification, font, background colour,
+	etc);</li>
+	<li>Keyboard
+	navigation and keyboard traps;</li>
+	<li>Data
+	validation;</li>
+	<li>Warning
+	of links opening in new tab or window;</li>
+	<li>Information
+	conveyed in the colour or sound only;</li>
+	<li>Flashing,
+	moving or scrolling text;</li>
+	<li>Operability if JavaScript is disabled;</li>
+	<li>Use
+	with screen reading software (for example JAWS);</li>
+	<li>Assistive
+	software (TextHelp Read and Write, Windows Magnifier, ZoomText,
+	Dragon Naturally Speaking, TalkBack and VoiceOver);</li>
+	<li>Tooltips
+	and text alternatives for any non-text content;</li>
+	<li>Time
+	limits;</li>
+	<li>Compatibility
+	with mobile accessibility functionality (Android and iOS);</li>
+	<li>Any
+	drag functionality and alternatives;</li>
+	<li>Consistent
+	help function;</li>
+	<li>Submission and re-entry of data;</li>
+	<li>Any
+	cognitive tests.
+	</li>
+</ul>
+
+<!-- {{Delete the entire Change Log section if this is the first manual test - i.e. no fixes have been implemented}} -->
+<!-- {{The fixes should be grouped by date.  They should contain a description of the fix and the WCAG element referred to - see example below. Entries should follow the same format as below}} -->
+
+<h2>Change Log</h2
+<p>
+Since the previous test, the following fixes were implemented in August 2024 based on the manual testing done.</p>
+<p>
+</p>
+
+<ul><li>The search bar colour contrast issues have been resolved to meet WCAG 2.2 AA standards. (16/08/2024). This partially but does not fully resolve the error:</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 - Contrast (Minimum)</a></p>
+
+<ul><li>Changed the text alignment from justified to left aligned (16/08/2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#visual-presentation">1.4.8 - Visual Presentation</a></p>
+
+<ul><li>Added a skip to main content button on each page. (16/08/2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#bypass-blocks">2.4.1 - Bypass Blocks</a></p>
+
+<ul><li>Implemented a consistent, high contrast focus highlighter function website wide. (16/08/2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG22/#focus-visible">2.4.7 - Focus Visible</a></p>
+
+<ul><li>Added a popup to notify users that a new tab is about to be opened after clicking on a link. (16/08/2024)</li></ul>
+<p><a href="https://www.w3.org/TR/WCAG21/#on-input">3.2.2 - On input</a></p>
+
+<ul><li>Removed the transparency of the text over images. (16/08/2024)</li></ul>
+
+<ul><li>Increased font size to at least 12pt (16/08/2024)</li></ul>
+
+<p>
+</p>
+</body>
 </html>

--- a/theme-local/physics/css/style.css
+++ b/theme-local/physics/css/style.css
@@ -56,7 +56,7 @@ input, select { vertical-align: middle; }
 
 
 /* Font normalization inspired by YUI Library's fonts.css: developer.yahoo.com/yui/ */
-body 								{ font:13px/1.231 sans-serif; *font-size:small; } /* Hack retained to preserve specificity */
+body 								{ font:12pt/1.231 sans-serif; *font-size:small; } /* Hack retained to preserve specificity */
 select, input, textarea, button 	{ font:99% sans-serif; }
 
 pre, code, kbd, samp 				{ font-family: monospace, sans-serif; } /* Normalize monospace sizing: en.wikipedia.org/wiki/MediaWiki_talk:Common.css/Archive_11#Teletype_style_fix_for_Chrome */
@@ -106,29 +106,29 @@ body 							{ background: #fff }
 body, select, input, textarea 	{ color: #555; line-height: 18px; font-family: Arial, Helvetica, sans-serif; }
 
 h1, h2, h3, h4, h5, h6 			{ text-rendering: optimizeLegibility; color: #00548e; font-weight: bold; }
-h1 								{ font-size: 18px; line-height: 24px; margin: 30px 0 17px 0px; position: relative; }
-h2 								{ font-size: 16px; line-height: 36px; margin: 0 0 0 0; }
-h3 								{ font-size: 14px; line-height: 18px; margin: 0 0 9px 0; }
+h1 								{ font-size: 24pt; line-height: 24px; margin: 30px 0 17px 0px; position: relative; }
+h2 								{ font-size: 20pt; line-height: 36px; margin: 0 0 0 0; }
+h3 								{ font-size: 16pt; line-height: 18px; margin: 0 0 9px 0; }
 
 h1.itemtitle 					{ font-size: 18px; line-height: 24px; margin: 30px 0 17px 10px; position: relative; }
 
-p 								{ font-size: 13px; margin-bottom: 18px; }
+p 								{ font-size: 12pt; margin-bottom: 18px; }
 
 a, a:active, a:visited 			{ color: #00548e; }
 a:hover 						{ color: #033a5f; }
 
 input[type=text], input[type=password]				{
-	border: 1px solid #bbbbbc; font-size: 13px; height: 28px; padding: 0 10px;
+	border: 1px solid #bbbbbc; font-size: 12pt; height: 28px; padding: 0 10px;
 	-webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px;
 }
 input.btn						{
-	background: #196599; border: none; height: 28px; color: #fff; text-transform: uppercase; font-size: 14px; margin-left: 8px; font-weight: bold; padding: 0 18px;
+	background: #196599; border: none; height: 28px; color: #fff; font-size: 14px; margin-left: 8px; font-weight: bold; padding: 0 18px;
 	-webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; text-shadow: rgba(0,0,0,0.3) 0px -1px 0px;
 }
 input.btn:hover					{ background: #033a5f; }
 
 input.backbtn				    {
-    background: #196599; border: none; height: 24px; color: #fff; text-transform: uppercase; font-size: 12px; margin-left: 8px; font-weight: bold; padding: 0 10px;
+    background: #196599; border: none; height: 24px; color: #fff;  font-size: 12pt; margin-left: 8px; font-weight: bold; padding: 0 10px;
     margin-top: 10px; margin-bottom: 10px;
     -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; text-shadow: rgba(0,0,0,0.3) 0px -1px 0px;
 }
@@ -173,21 +173,21 @@ header				{ position: relative; }
 }
 .ie7 .search input[type=text]	{ width: 355px; }
 .search input.btn				{ margin-right: 8px; }
-.search .advanced 				{ text-transform: uppercase; font-size: 10px; text-decoration: none; }
+.search .advanced 				{ font-size: 12pt; text-decoration: none; display: inline-block; max-width: min-content; vertical-align: middle; text-align: center;}
 .search .advanced:hover			{ text-decoration: underline; }
 
 .header-links 					{ position: absolute; top: 16px; left: 0; overflow: hidden; }
-.header-links a 				{ font-size: 10px; text-transform: uppercase; float: left; text-decoration: none; padding-right: 10px; margin-right: 10px; border-right: 1px solid #b8c1c6; line-height: 12px;  }
+.header-links a 				{ font-size: 12pt;  float: left; text-decoration: none; padding-right: 10px; margin-right: 10px; border-right: 1px solid #b8c1c6; line-height: 12px;  }
 .header-links a:hover			{ text-decoration: underline; }
 .header-links a.last			{ border: none; }
 
-.col-sidebar h4						{ color: #fff; line-height: 26px; font-weight: bold; text-transform: uppercase; font-size: 12px; margin-bottom: 17px; background: #196599; padding: 0 17px; }
+.col-sidebar h4						{ color: #fff; line-height: 26px; font-weight: bold; font-size: 12pt; margin-bottom: 17px; background: #196599; padding: 0 17px; }
 .col-sidebar h4 a 					{ 
 	background: #196599 url(../images/bg-arrows.png) no-repeat 100% -92px;
 	display: block; color: #fff; text-decoration: none; width: 223px; padding-left: 17px; position: relative; left: -17px;
 }
 .col-sidebar h4 a:hover				{ background: #033a5f url(../images/bg-arrows.png) no-repeat 100% -92px; }
-.col-sidebar ul 					{ list-style-type: none; margin: 0 0 17px 0; font-size: 12px; }
+.col-sidebar ul 					{ list-style-type: none; margin: 0 0 17px 0; font-size: 12pt; }
 .col-sidebar ul li 					{ line-height: 16px; padding: 0 17px; }
 .col-sidebar ul a 					{ text-decoration: none; display: block; }
 .col-sidebar ul a:hover				{ text-decoration: underline; }
@@ -206,8 +206,8 @@ header				{ position: relative; }
 .col-sidebar ul.related .tags a 			{ padding: 2px 5px; display: inline; background: #ffffff; }
 .col-sidebar ul.related .tags a:hover		{ text-decoration: none; background: #00548e; }
 
-footer 								{ margin-top: 40px; }
-footer a 							{ font-size: 10px; text-transform: uppercase; color: #666 !important; text-decoration: none; font-weight: bold; border-right: 1px solid #cecece; padding-right: 9px; margin-right: 5px; }
+footer 								{ margin-top: 40px; text-wrap-mode: nowrap;}
+footer a 							{ font-size: 12pt;  color: #666 !important; text-decoration: none; font-weight: bold; border-right: 1px solid #cecece; padding-right: 9px; margin-right: 5px; }
 footer a.last						{ border: none; }
 footer a:hover						{ color: #333 !important; text-decoration: underline; }
 
@@ -222,17 +222,17 @@ footer a:hover						{ color: #333 !important; text-decoration: underline; }
 .listing li a:hover					{ text-decoration: none; }
 .listing li .tags a:hover			{ text-decoration: none; }
 .listing li h3 						{ margin-bottom: 8px; }
-.listing li p 						{ font-size: 12px; margin: 0; }
+.listing li p 						{ font-size: 12pt; margin: 0; }
 
 .tags					{ margin: 0 0 0 10px; }
-.tags a 				{ font-size: 13px; background: #def5fb; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 20px; margin-right: 8px; text-decoration: none; }
+.tags a 				{ font-size: 12pt; background: #def5fb; -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; padding: 2px 6px; line-height: 18pt; margin-right: 8px; text-decoration: none; }
 .tags a.bold			{ font-weight: bold; }
 .tags a:hover			{ background: #00548e; color: #fff; }
 
 .listing-filter						{ padding: 0; border: none; border-bottom: 1px solid #b8baba; line-height: 33px; text-align: right; position: relative; }
 .listing-filter .no-results			{ position: absolute; top: 0; left: 0; }
 .ie7 .listing-filter .no-results	{ top: -10px; }
-.listing-filter .sort				{ font-size: 10px; text-transform: uppercase; color: #666; padding-right: 10px; }
+.listing-filter .sort				{ font-size: 12pt;  color: #666; padding-right: 10px; }
 .listing-filter .sort a 			{ text-decoration: none; }
 .listing-filter .sort a:hover		{ text-decoration: underline; }
 .listing-filter .sort strong		{ color: #333; }
@@ -262,12 +262,12 @@ h1 .icon							{ top: -5px; left: -65px; }
 .small-icon.media-img				{ background-position: 0px -40px; }
 .small-icon.media-book				{ background-position: 0px -60px; }
 
-.pagination							{ border-bottom: 1px solid #b8baba; border-top: 1px solid #b8baba; line-height: 33px; text-align: center; position: relative; font-size: 11px; font-weight: bold; }
+.pagination							{ border-bottom: 1px solid #b8baba; border-top: 1px solid #b8baba; line-height: 33px; text-align: center; position: relative; font-size: 12pt; font-weight: bold; }
 .pagination a 						{ color: #666; text-decoration: none; display: inline-block; padding: 0 5px; }
 .pagination a.selected 				{ background: #e8e8e8; color: #333; }
 .pagination a:hover					{ color: #333; text-decoration: underline; }
 .pagination .prev,
-.pagination .next					{ display: block; position: absolute; top: 0; font-size: 11px; background: url(../images/bg-arrows.png) no-repeat 0px 0px; }
+.pagination .next					{ display: block; position: absolute; top: 0; font-size: 12pt; background: url(../images/bg-arrows.png) no-repeat 0px 0px; }
 .pagination .prev					{ left: 0; padding: 0 10px 0 25px; }
 .pagination .next					{ right: 0; padding: 0 25px 0 10px; background-position: 100% -33px !important; }
 .pagination .prev:hover,
@@ -277,7 +277,7 @@ h1 .icon							{ top: -5px; left: -65px; }
 .content ul 						{ margin: 0 0 18px 1.2em; }
 
 table								{ width: 100%; background: #f1f1f2; }
-table caption						{ text-align: left; background: #677077; color: #fff; font-size: 12px; text-transform: uppercase; font-weight: bold; padding: 8px 17px; border-bottom: 1px solid #fff;  }
+table caption						{ text-align: left; background: #677077; color: #fff; font-size: 12pt;  font-weight: bold; padding: 8px 17px; border-bottom: 1px solid #fff;  }
 table td, table th					{ padding: 8px 17px; }
 table th							{ text-align: left; border-right: 1px solid #fff;  }
 table tr:nth-child(2n)				{ background: #e7e8ea; }
@@ -343,3 +343,49 @@ span[id^="video-"]              { margin: 5px 0; }
   h2, h3{ page-break-after: avoid; }
 }
 
+/* Accessibility --------------------------------------------------------------------------------------------------------*/
+
+:focus, a:focus, .clickbox:focus-within, .search input:focus{ 
+  box-shadow: rgba(255, 150, 0, 0.7) 0px 0px 10px 6px, rgb(255, 150, 0) 0px 0px 0px 2.5px; 
+  z-index: 9999; 
+  outline:none;
+}
+
+.sr-only {
+    position: absolute !important;
+    clip-path: circle(0%);
+    border: 0;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    width: 1px;
+    word-wrap: normal!important;
+}
+
+.sr-only:hover, .sr-only:active, .sr-only:focus {
+    z-index: 100000;
+    top: 5px;
+    left: 5px;
+    display: block;
+    width: auto;
+    height: auto;
+    text-decoration: none;
+    color: black;
+    border-radius: 3px;
+    background-color: #F3E3D4;
+    font-size: 12pt;
+    font-weight: bold;
+    line-height: normal;
+    clip-path: circle(100%);
+    padding: 8px;
+}
+
+/* For regular external links (excluding those with .logo class) */
+a[target="_blank"]:not(.uoelogo):not(.menulogo):not(:has(.social)):not(.clickbox > * a)::after {
+    content: "\f08e";
+    font-family: FontAwesome;
+    right: -2px;
+    position: relative;
+    font-size: 0.8em;
+}

--- a/theme/physics/views/div_main_end.php
+++ b/theme/physics/views/div_main_end.php
@@ -1,10 +1,10 @@
 <footer>
     <div class="footer-disclaimer">
         <div class="footer-policies">
-            <p><a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank">Privacy &amp; Cookies</a>
+            <p><a href="https://www.ed.ac.uk/about/website/privacy" title="Privacy and Cookies Link"  target="_blank">Privacy &amp; Cookies<span class="sr-only"> (Opens in a new tab)</span></a>
                 &nbsp;&nbsp;<a href="./takedown" title="Takedown Policy Link">Takedown Policy</a>
                 &nbsp;&nbsp;<a href="./licensing" title="Licensing and Copyright Link">Licensing &amp; Copyright</a>
-                &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank">Accessibility</a></p>
+                &nbsp;&nbsp;<a href="./accessibility" title="Website Accessibility Link" target="_blank">Accessibility<span class="sr-only"> (Opens in a new tab)</span></a></p>
         </div>
     </div>
 

--- a/theme/physics/views/header.php
+++ b/theme/physics/views/header.php
@@ -100,13 +100,15 @@
 </head>
 
 <body>
-
+<div class="skip-links">
+    <a class="sr-only" href="<?php echo current_url(); ?>#main">Skip to content</a>
+</div>
 <div id="container">
     <header>
         <div id="collection-title">
-            <a href="https://www.ed.ac.uk" class="uoelogo" title="The University of Edinburgh" target="_blank"></a>
+            <a href="https://www.ed.ac.uk" class="uoelogo" title="The University of Edinburgh (Link opens in a new tab)" target="_blank"><span class="sr-only"> (Opens in a new tab)</span></a>
             <a href="<?php echo base_url(); ?>" class="physicslogo" title="School of Physics & Astronomy Image Archive"></a>
-            <a href="http://www.ph.ed.ac.uk" class="menulogo" title="School of Physics & Astronomy" target="_blank"></a>
+            <a href="http://www.ph.ed.ac.uk" class="menulogo" title="School of Physics & Astronomy (Link opens in a new tab)" target="_blank"><span class="sr-only"> (Opens in a new tab)</span></a>
         </div>
         <div id="collection-search">
             <form action="./redirect/" method="post">

--- a/theme/physics/views/record.php
+++ b/theme/physics/views/record.php
@@ -119,7 +119,7 @@ if(isset($solr[$type_field])) {
                         $jpeg_thumb = strpos($t_filename, '.JPG.jpg');
                     }
                     if ($jpeg_thumb !== false) {
-                        $thumbnailLink = '<a title = "' . $solr[$title_field][0] . '" class="fancybox"' . ' href="' . $b_uri . '"><img src = "' . $t_uri . '" title="' . $solr[$title_field][0] . '" /></a> ';
+                        $thumbnailLink = '<a title = "' . $solr[$title_field][0] . '" class="fancybox"' . ' href="' . $b_uri . '"><img src = "' . $t_uri . '" title="' . $solr[$title_field][0] . '" alt="' . $solr[$this->skylight_utilities->getField('Description')][0] . '" /></a> ';
                         echo $thumbnailLink;
                     }
                 }

--- a/theme/physics/views/search_results.php
+++ b/theme/physics/views/search_results.php
@@ -8,6 +8,7 @@
         $author_field = $this->skylight_utilities->getField('Author');
         $date_field = $this->skylight_utilities->getField('Date');
         $type_field = $this->skylight_utilities->getField('Type');
+        $description_field = $this->skylight_utilities->getField('Description');
         $bitstream_field = $this->skylight_utilities->getField('Bitstream');
         $thumbnail_field = $this->skylight_utilities->getField('Thumbnail');
         $abstract_field = $this->skylight_utilities->getField('Abstract');
@@ -131,7 +132,7 @@
                         $t_seq = $t_segments[4];
                         $handle_id = preg_replace('/^.*\//', '',$t_handle);
                         $t_uri = './record/'.$handle_id.'/'.$t_seq.'/'.$t_filename;
-                        $thumbnailLink = '<img src = "'.$t_uri.'" class="search-thumbnail" title="'. $doc[$title_field][0] .'" />';
+                        $thumbnailLink = '<img src = "'.$t_uri.'" class="search-thumbnail" title="'. $doc[$title_field][0] .'" alt="' . $doc[$description_field][0] .'" />';
                         echo $thumbnailLink;
                         break 2;
                        /* if ($t_filename == $b_filename.'.jpg') {


### PR DESCRIPTION
SOPA accessibility fixes:
- Removed continuous capitals
- Added record descriptions as alt text to images
- Made the focus outline clearer
- Font size adjustments
- Added skip to content button
- Added icons and sr text warning users of links that open in a new tab

Accessibility statements updated:
- Scottish Government Yearbooks (iog)
- St. Cecilia's Hall Musical Instruments Collection (stcecilias)
- Art Collection (art)